### PR TITLE
docs: document doStream synchronous callback contract

### DIFF
--- a/packages/ai/src/generate-text/stream-text.zig
+++ b/packages/ai/src/generate-text/stream-text.zig
@@ -411,10 +411,11 @@ pub fn streamText(
         }
     };
 
+    // Safety: bridge is stack-allocated but this is safe because doStream
+    // completes all callbacks synchronously before returning. See the
+    // doStream contract in LanguageModelV3.VTable.
     var bridge = BridgeCtx{ .res = result, .cbs = options.callbacks };
     const bridge_ptr: *anyopaque = @ptrCast(&bridge);
-
-    // Call model's doStream
     options.model.doStream(call_options, allocator, .{
         .on_part = BridgeCtx.onPart,
         .on_error = BridgeCtx.onError,

--- a/packages/provider/src/language-model/v3/language-model-v3.zig
+++ b/packages/provider/src/language-model/v3/language-model-v3.zig
@@ -57,7 +57,10 @@ pub const LanguageModelV3 = struct {
             ?*anyopaque,
         ) void,
 
-        /// Generate a language model output (streaming)
+        /// Generate a language model output (streaming).
+        /// IMPORTANT: Implementations MUST complete all callbacks synchronously
+        /// before returning. The caller may pass stack-allocated context via
+        /// StreamCallbacks.ctx that becomes invalid after doStream returns.
         doStream: *const fn (
             *anyopaque,
             LanguageModelV3CallOptions,
@@ -176,7 +179,9 @@ pub const LanguageModelV3 = struct {
         self.vtable.doGenerate(self.impl, options, allocator, callback, ctx);
     }
 
-    /// Generate a response (streaming)
+    /// Generate a response (streaming).
+    /// All callbacks are invoked synchronously before this function returns.
+    /// Callers may safely pass stack-allocated context via callbacks.ctx.
     pub fn doStream(
         self: Self,
         options: LanguageModelV3CallOptions,


### PR DESCRIPTION
## Summary
- Documents the synchronous callback contract for `doStream` in the `LanguageModelV3` vtable interface
- Adds safety comments in `streamText` explaining why stack-allocated bridge context is safe
- Clarifies that implementations MUST complete all callbacks before returning

Closes #2

## Test plan
- [x] All 1139 existing tests pass
- [x] No behavior changes, documentation-only fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)