### PR TITLE
refactor: migrate deprecated std.array_list.Managed to std.ArrayList

### DIFF
--- a/packages/ai/src/generate-object/generate-object.zig
+++ b/packages/ai/src/generate-object/generate-object.zig
@@ -134,8 +134,8 @@ pub fn generateObject(
     }
 
     // Build system prompt with schema instructions
-    var system_parts = std.array_list.Managed(u8).init(arena_allocator);
-    const writer = system_parts.writer();
+    var system_parts = std.ArrayList(u8).empty;
+    const writer = system_parts.writer(arena_allocator);
 
     if (options.system) |sys| {
         writer.writeAll(sys) catch return GenerateObjectError.OutOfMemory;
@@ -149,15 +149,15 @@ pub fn generateObject(
     writer.writeAll(schema_json) catch return GenerateObjectError.OutOfMemory;
 
     // Build prompt messages for the model
-    var prompt_msgs = std.array_list.Managed(provider_types.LanguageModelV3Message).init(arena_allocator);
+    var prompt_msgs = std.ArrayList(provider_types.LanguageModelV3Message).empty;
 
     // Add system message with schema instructions
-    prompt_msgs.append(provider_types.language_model.systemMessage(system_parts.items)) catch return GenerateObjectError.OutOfMemory;
+    prompt_msgs.append(arena_allocator, provider_types.language_model.systemMessage(system_parts.items)) catch return GenerateObjectError.OutOfMemory;
 
     // Add user message
     if (options.prompt) |prompt| {
         const msg = provider_types.language_model.userTextMessage(arena_allocator, prompt) catch return GenerateObjectError.OutOfMemory;
-        prompt_msgs.append(msg) catch return GenerateObjectError.OutOfMemory;
+        prompt_msgs.append(arena_allocator, msg) catch return GenerateObjectError.OutOfMemory;
     }
 
     // Build call options

--- a/packages/ai/src/middleware/middleware.zig
+++ b/packages/ai/src/middleware/middleware.zig
@@ -92,30 +92,30 @@ pub const MiddlewareContext = struct {
 /// Middleware chain for processing requests/responses
 pub const MiddlewareChain = struct {
     allocator: std.mem.Allocator,
-    request_middleware: std.array_list.Managed(RequestMiddleware),
-    response_middleware: std.array_list.Managed(ResponseMiddleware),
+    request_middleware: std.ArrayList(RequestMiddleware),
+    response_middleware: std.ArrayList(ResponseMiddleware),
 
     pub fn init(allocator: std.mem.Allocator) MiddlewareChain {
         return .{
             .allocator = allocator,
-            .request_middleware = std.array_list.Managed(RequestMiddleware).init(allocator),
-            .response_middleware = std.array_list.Managed(ResponseMiddleware).init(allocator),
+            .request_middleware = std.ArrayList(RequestMiddleware).empty,
+            .response_middleware = std.ArrayList(ResponseMiddleware).empty,
         };
     }
 
     pub fn deinit(self: *MiddlewareChain) void {
-        self.request_middleware.deinit();
-        self.response_middleware.deinit();
+        self.request_middleware.deinit(self.allocator);
+        self.response_middleware.deinit(self.allocator);
     }
 
     /// Add request middleware
     pub fn useRequest(self: *MiddlewareChain, middleware: RequestMiddleware) !void {
-        try self.request_middleware.append(middleware);
+        try self.request_middleware.append(self.allocator, middleware);
     }
 
     /// Add response middleware
     pub fn useResponse(self: *MiddlewareChain, middleware: ResponseMiddleware) !void {
-        try self.response_middleware.append(middleware);
+        try self.response_middleware.append(self.allocator, middleware);
     }
 
     /// Process request through all middleware

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.zig
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.zig
@@ -77,8 +77,8 @@ pub const BedrockChatLanguageModel = struct {
         }
 
         // Serialize request body
-        var body_buffer = std.array_list.Managed(u8).init(request_allocator);
-        std.json.stringify(request_body, .{}, body_buffer.writer()) catch |err| {
+        var body_buffer = std.ArrayList(u8).empty;
+        std.json.stringify(request_body, .{}, body_buffer.writer(request_allocator)) catch |err| {
             callback(null, err, callback_context);
             return;
         };

--- a/packages/anthropic/src/anthropic-prepare-tools.zig
+++ b/packages/anthropic/src/anthropic-prepare-tools.zig
@@ -35,7 +35,7 @@ pub fn prepareTools(
     allocator: std.mem.Allocator,
     options: PrepareToolsOptions,
 ) !PrepareToolsResult {
-    var warnings = std.array_list.Managed(shared.SharedV3Warning).init(allocator);
+    var warnings = std.ArrayList(shared.SharedV3Warning).empty;
     var betas = std.StringHashMap(void).init(allocator);
 
     // Convert tools
@@ -78,7 +78,7 @@ pub fn prepareTools(
                             try betas.put("computer-use-2024-10-22", {});
                         }
                     } else {
-                        try warnings.append(shared.SharedV3Warning.otherWarning(
+                        try warnings.append(allocator, shared.SharedV3Warning.otherWarning(
                             try std.fmt.allocPrint(
                                 allocator,
                                 "Provider tool '{s}' is not supported in Anthropic messages API",
@@ -129,7 +129,7 @@ pub fn prepareTools(
     return .{
         .tools = anthropic_tools,
         .tool_choice = anthropic_tool_choice,
-        .tool_warnings = try warnings.toOwnedSlice(),
+        .tool_warnings = try warnings.toOwnedSlice(allocator),
         .betas = betas,
     };
 }

--- a/packages/cohere/src/cohere-chat-language-model.zig
+++ b/packages/cohere/src/cohere-chat-language-model.zig
@@ -76,8 +76,8 @@ pub const CohereChatLanguageModel = struct {
         }
 
         // Serialize request body
-        var body_buffer = std.array_list.Managed(u8).init(request_allocator);
-        std.json.stringify(request_body, .{}, body_buffer.writer()) catch |err| {
+        var body_buffer = std.ArrayList(u8).empty;
+        std.json.stringify(request_body, .{}, body_buffer.writer(request_allocator)) catch |err| {
             callback(null, err, callback_context);
             return;
         };
@@ -183,10 +183,10 @@ pub const CohereChatLanguageModel = struct {
                     var message = std.json.ObjectMap.init(allocator);
                     try message.put("role", .{ .string = "user" });
 
-                    var text_parts = std.array_list.Managed([]const u8).init(allocator);
+                    var text_parts = std.ArrayList([]const u8).empty;
                     for (msg.content.user) |part| {
                         switch (part) {
-                            .text => |t| try text_parts.append(t.text),
+                            .text => |t| try text_parts.append(allocator, t.text),
                             else => {},
                         }
                     }
@@ -199,12 +199,12 @@ pub const CohereChatLanguageModel = struct {
                     var message = std.json.ObjectMap.init(allocator);
                     try message.put("role", .{ .string = "assistant" });
 
-                    var text_content = std.array_list.Managed([]const u8).init(allocator);
+                    var text_content = std.ArrayList([]const u8).empty;
                     var tool_calls = std.json.Array.init(allocator);
 
                     for (msg.content.assistant) |part| {
                         switch (part) {
-                            .text => |t| try text_content.append(t.text),
+                            .text => |t| try text_content.append(allocator, t.text),
                             .tool_call => |tc| {
                                 var tool_call = std.json.ObjectMap.init(allocator);
                                 try tool_call.put("id", .{ .string = tc.tool_call_id });

--- a/packages/deepgram/src/deepgram-provider.zig
+++ b/packages/deepgram/src/deepgram-provider.zig
@@ -81,8 +81,8 @@ pub const DeepgramTranscriptionModel = struct {
         self: *const Self,
         options: TranscriptionOptions,
     ) ![]const u8 {
-        var params = std.array_list.Managed(u8).init(self.allocator);
-        var writer = params.writer();
+        var params = std.ArrayList(u8).empty;
+        var writer = params.writer(self.allocator);
 
         try writer.print("model={s}", .{self.model_id});
 
@@ -164,7 +164,7 @@ pub const DeepgramTranscriptionModel = struct {
             try writer.print("&intents={}", .{i});
         }
 
-        return params.toOwnedSlice();
+        return params.toOwnedSlice(self.allocator);
     }
 };
 

--- a/packages/deepseek/src/deepseek-chat-language-model.zig
+++ b/packages/deepseek/src/deepseek-chat-language-model.zig
@@ -142,10 +142,10 @@ pub const DeepSeekChatLanguageModel = struct {
                     var message = std.json.ObjectMap.init(allocator);
                     try message.put("role", .{ .string = "user" });
 
-                    var text_parts = std.ArrayList([]const u8).init(allocator);
+                    var text_parts = std.ArrayList([]const u8).empty;
                     for (msg.content.user) |part| {
                         switch (part) {
-                            .text => |t| try text_parts.append(t.text),
+                            .text => |t| try text_parts.append(allocator, t.text),
                             else => {},
                         }
                     }
@@ -158,12 +158,12 @@ pub const DeepSeekChatLanguageModel = struct {
                     var message = std.json.ObjectMap.init(allocator);
                     try message.put("role", .{ .string = "assistant" });
 
-                    var text_content = std.ArrayList([]const u8).init(allocator);
+                    var text_content = std.ArrayList([]const u8).empty;
                     var tool_calls = std.json.Array.init(allocator);
 
                     for (msg.content.assistant) |part| {
                         switch (part) {
-                            .text => |t| try text_content.append(t.text),
+                            .text => |t| try text_content.append(allocator, t.text),
                             .tool_call => |tc| {
                                 var tool_call = std.json.ObjectMap.init(allocator);
                                 try tool_call.put("id", .{ .string = tc.tool_call_id });
@@ -267,7 +267,6 @@ pub const DeepSeekChatLanguageModel = struct {
         ctx: ?*anyopaque,
     ) void {
         _ = self;
-        _ = allocator;
         callback(ctx, .{ .success = std.StringHashMap([]const []const u8).init(allocator) });
     }
 

--- a/packages/google-vertex/src/google-vertex-image-model.zig
+++ b/packages/google-vertex/src/google-vertex-image-model.zig
@@ -65,11 +65,11 @@ pub const GoogleVertexImageModel = struct {
         defer arena.deinit();
         const request_allocator = arena.allocator();
 
-        var warnings = std.ArrayList(shared.SharedV3Warning).init(request_allocator);
+        var warnings = std.ArrayList(shared.SharedV3Warning).empty;
 
         // Check for size option (not supported)
         if (call_options.size != null) {
-            warnings.append(.{
+            warnings.append(request_allocator, .{
                 .type = .unsupported,
                 .message = "size option not supported, use aspectRatio instead",
             }) catch |err| {
@@ -347,8 +347,8 @@ pub const GoogleVertexImageModel = struct {
         };
 
         // Serialize request body
-        var body_buffer = std.ArrayList(u8).init(request_allocator);
-        std.json.stringify(.{ .object = body }, .{}, body_buffer.writer()) catch |err| {
+        var body_buffer = std.ArrayList(u8).empty;
+        std.json.stringify(.{ .object = body }, .{}, body_buffer.writer(request_allocator)) catch |err| {
             callback(callback_context, .{ .failure = err });
             return;
         };
@@ -360,10 +360,10 @@ pub const GoogleVertexImageModel = struct {
         };
 
         // Convert headers to slice
-        var header_list = std.ArrayList(provider_utils.HttpHeader).init(request_allocator);
+        var header_list = std.ArrayList(provider_utils.HttpHeader).empty;
         var header_iter = headers.iterator();
         while (header_iter.next()) |entry| {
-            header_list.append(.{
+            header_list.append(request_allocator, .{
                 .name = entry.key_ptr.*,
                 .value = entry.value_ptr.*,
             }) catch |err| {
@@ -422,7 +422,7 @@ pub const GoogleVertexImageModel = struct {
         const response = parsed.value;
 
         // Extract images from response
-        var images_list = std.ArrayList([]const u8).init(result_allocator);
+        var images_list = std.ArrayList([]const u8).empty;
         if (response.predictions) |predictions| {
             for (predictions) |pred| {
                 if (pred.bytesBase64Encoded) |b64| {
@@ -430,7 +430,7 @@ pub const GoogleVertexImageModel = struct {
                         callback(callback_context, .{ .failure = err });
                         return;
                     };
-                    images_list.append(b64_copy) catch |err| {
+                    images_list.append(result_allocator, b64_copy) catch |err| {
                         callback(callback_context, .{ .failure = err });
                         return;
                     };
@@ -439,8 +439,8 @@ pub const GoogleVertexImageModel = struct {
         }
 
         const result = image.ImageModelV3.GenerateSuccess{
-            .images = .{ .base64 = images_list.toOwnedSlice() catch &[_][]const u8{} },
-            .warnings = warnings.toOwnedSlice() catch &[_]shared.SharedV3Warning{},
+            .images = .{ .base64 = images_list.toOwnedSlice(result_allocator) catch &[_][]const u8{} },
+            .warnings = warnings.toOwnedSlice(request_allocator) catch &[_]shared.SharedV3Warning{},
             .response = .{
                 .timestamp = std.time.milliTimestamp(),
                 .model_id = self.model_id,

--- a/packages/mistral/src/mistral-embedding-model.zig
+++ b/packages/mistral/src/mistral-embedding-model.zig
@@ -133,16 +133,16 @@ pub const MistralEmbeddingModel = struct {
         }
 
         // Convert embeddings to proper format
-        var embed_list = std.ArrayList(embedding.EmbeddingModelV3Embedding).init(result_allocator);
+        var embed_list = std.ArrayList(embedding.EmbeddingModelV3Embedding).empty;
         for (embeddings) |emb| {
-            embed_list.append(.{ .embedding = .{ .float = emb } }) catch |err| {
+            embed_list.append(result_allocator, .{ .embedding = .{ .float = emb } }) catch |err| {
                 callback(callback_context, .{ .failure = err });
                 return;
             };
         }
 
         const result = embedding.EmbeddingModelV3.EmbedSuccess{
-            .embeddings = embed_list.toOwnedSlice() catch &[_]embedding.EmbeddingModelV3Embedding{},
+            .embeddings = embed_list.toOwnedSlice(result_allocator) catch &[_]embedding.EmbeddingModelV3Embedding{},
             .usage = null,
             .warnings = &[_]shared.SharedV3Warning{},
         };

--- a/packages/openai/src/chat/openai-chat-prepare-tools.zig
+++ b/packages/openai/src/chat/openai-chat-prepare-tools.zig
@@ -29,7 +29,7 @@ pub fn prepareChatTools(
     allocator: std.mem.Allocator,
     options: PrepareToolsOptions,
 ) !PrepareToolsResult {
-    var warnings = std.array_list.Managed(shared.SharedV3Warning).init(allocator);
+    var warnings = std.ArrayList(shared.SharedV3Warning).empty;
 
     // Convert tools
     var openai_tools: ?[]api.OpenAIChatRequest.Tool = null;
@@ -52,7 +52,7 @@ pub fn prepareChatTools(
                 },
                 .provider => |prov| {
                     // Provider tools are not directly supported in chat API
-                    try warnings.append(.{
+                    try warnings.append(allocator, .{
                         .other = .{
                             .message = try std.fmt.allocPrint(
                                 allocator,
@@ -92,7 +92,7 @@ pub fn prepareChatTools(
     return .{
         .tools = openai_tools,
         .tool_choice = openai_tool_choice,
-        .tool_warnings = try warnings.toOwnedSlice(),
+        .tool_warnings = try warnings.toOwnedSlice(allocator),
     };
 }
 

--- a/packages/provider-utils/src/combine-headers.zig
+++ b/packages/provider-utils/src/combine-headers.zig
@@ -20,16 +20,16 @@ pub fn combineHeaders(
     }
 
     // Convert to slice
-    var list = std.array_list.Managed(http_client.HttpClient.Header).init(allocator);
+    var list = std.ArrayList(http_client.HttpClient.Header).empty;
     var iter = result.iterator();
     while (iter.next()) |entry| {
-        try list.append(.{
+        try list.append(allocator, .{
             .name = entry.key_ptr.*,
             .value = entry.value_ptr.*,
         });
     }
 
-    return list.toOwnedSlice();
+    return list.toOwnedSlice(allocator);
 }
 
 /// Combine headers from slices without allocation (returns iterator)

--- a/packages/provider-utils/src/generate-id.zig
+++ b/packages/provider-utils/src/generate-id.zig
@@ -175,16 +175,16 @@ test "IdGenerator uniqueness" {
 
     var generator = createIdGenerator();
 
-    var ids = std.array_list.Managed([]u8).init(allocator);
+    var ids = std.ArrayList([]u8).empty;
     defer {
         for (ids.items) |id| allocator.free(id);
-        ids.deinit();
+        ids.deinit(allocator);
     }
 
     // Generate multiple IDs and verify they're unique
     for (0..100) |_| {
         const id = try generator.generate(allocator);
-        try ids.append(id);
+        try ids.append(allocator, id);
     }
 
     // Check uniqueness

--- a/packages/provider-utils/src/post-to-api.zig
+++ b/packages/provider-utils/src/post-to-api.zig
@@ -65,11 +65,11 @@ pub fn postJsonToApi(
     };
 
     // Build headers list
-    var headers_list = std.array_list.Managed(http_client.HttpClient.Header).init(allocator);
-    defer headers_list.deinit();
+    var headers_list = std.ArrayList(http_client.HttpClient.Header).empty;
+    defer headers_list.deinit(allocator);
 
     // Add Content-Type header
-    headers_list.append(.{
+    headers_list.append(allocator, .{
         .name = "Content-Type",
         .value = "application/json",
     }) catch {
@@ -86,7 +86,7 @@ pub fn postJsonToApi(
     // Add custom headers
     if (options.headers) |custom_headers| {
         for (custom_headers) |h| {
-            headers_list.append(h) catch {
+            headers_list.append(allocator, h) catch {
                 allocator.free(body);
                 callbacks.on_error(callbacks.ctx, .{
                     .info = errors.ApiCallError.init(.{
@@ -208,13 +208,13 @@ pub fn postToApi(
     callbacks: ApiCallbacks,
 ) void {
     // Build headers list
-    var headers_list = std.array_list.Managed(http_client.HttpClient.Header).init(allocator);
-    defer headers_list.deinit();
+    var headers_list = std.ArrayList(http_client.HttpClient.Header).empty;
+    defer headers_list.deinit(allocator);
 
     // Add custom headers
     if (options.headers) |custom_headers| {
         for (custom_headers) |h| {
-            headers_list.append(h) catch {
+            headers_list.append(allocator, h) catch {
                 callbacks.on_error(callbacks.ctx, .{
                     .info = errors.ApiCallError.init(.{
                         .message = "Failed to append header to request",
@@ -344,11 +344,11 @@ pub fn postJsonToApiStreaming(
     };
 
     // Build headers list
-    var headers_list = std.array_list.Managed(http_client.HttpClient.Header).init(allocator);
-    defer headers_list.deinit();
+    var headers_list = std.ArrayList(http_client.HttpClient.Header).empty;
+    defer headers_list.deinit(allocator);
 
     // Add Content-Type header
-    headers_list.append(.{
+    headers_list.append(allocator, .{
         .name = "Content-Type",
         .value = "application/json",
     }) catch {
@@ -365,7 +365,7 @@ pub fn postJsonToApiStreaming(
     // Add custom headers
     if (options.headers) |custom_headers| {
         for (custom_headers) |h| {
-            headers_list.append(h) catch {
+            headers_list.append(allocator, h) catch {
                 allocator.free(body);
                 callbacks.on_error(callbacks.ctx, .{
                     .info = errors.ApiCallError.init(.{

--- a/packages/provider-utils/src/url-validation.zig
+++ b/packages/provider-utils/src/url-validation.zig
@@ -45,21 +45,21 @@ pub fn normalizeUrl(url: []const u8, allocator: std.mem.Allocator) ![]const u8 {
     if (!has_duplicates) return url;
 
     // Build normalized URL
-    var result = std.array_list.Managed(u8).init(allocator);
-    errdefer result.deinit();
+    var result = std.ArrayList(u8).empty;
+    errdefer result.deinit(allocator);
 
     // Copy everything up to and including the first path slash
-    try result.appendSlice(url[0 .. path_start + 1]);
+    try result.appendSlice(allocator, url[0 .. path_start + 1]);
 
     // Copy path, collapsing duplicate slashes
     var prev_was_slash = true; // we just wrote the first slash
     for (url[path_start + 1 ..]) |c| {
         if (c == '/' and prev_was_slash) continue;
-        try result.append(c);
+        try result.append(allocator, c);
         prev_was_slash = (c == '/');
     }
 
-    return result.toOwnedSlice();
+    return result.toOwnedSlice(allocator);
 }
 
 // ============================================================================

--- a/packages/provider/src/errors/ai-sdk-error.zig
+++ b/packages/provider/src/errors/ai-sdk-error.zig
@@ -89,9 +89,9 @@ pub const AiSdkErrorInfo = struct {
 
     /// Format the error for display
     pub fn format(self: AiSdkErrorInfo, allocator: std.mem.Allocator) ![]const u8 {
-        var list = std.array_list.Managed(u8).init(allocator);
-        errdefer list.deinit();
-        const writer = list.writer();
+        var list = std.ArrayList(u8).empty;
+        errdefer list.deinit(allocator);
+        const writer = list.writer(allocator);
 
         try writer.print("{s}: {s}", .{ self.name(), self.message });
 
@@ -99,7 +99,7 @@ pub const AiSdkErrorInfo = struct {
             try writer.print("\nCaused by: {s}", .{cause.message});
         }
 
-        return list.toOwnedSlice();
+        return list.toOwnedSlice(allocator);
     }
 };
 

--- a/packages/provider/src/errors/api-call-error.zig
+++ b/packages/provider/src/errors/api-call-error.zig
@@ -100,9 +100,9 @@ pub const ApiCallError = struct {
 
     /// Format for display
     pub fn format(self: Self, allocator: std.mem.Allocator) ![]const u8 {
-        var list = std.array_list.Managed(u8).init(allocator);
-        errdefer list.deinit();
-        const writer = list.writer();
+        var list = std.ArrayList(u8).empty;
+        errdefer list.deinit(allocator);
+        const writer = list.writer(allocator);
 
         try writer.print("API call failed: {s}\n", .{self.info.message});
         try writer.print("URL: {s}\n", .{self.url()});
@@ -124,7 +124,7 @@ pub const ApiCallError = struct {
 
         try writer.print("Retryable: {}\n", .{self.isRetryable()});
 
-        return list.toOwnedSlice();
+        return list.toOwnedSlice(allocator);
     }
 };
 

--- a/packages/provider/src/errors/api-error-details.zig
+++ b/packages/provider/src/errors/api-error-details.zig
@@ -49,9 +49,9 @@ pub const ApiErrorDetails = struct {
 
     /// Format error details for display
     pub fn format(self: *const ApiErrorDetails, allocator: std.mem.Allocator) ![]const u8 {
-        var list = std.array_list.Managed(u8).init(allocator);
-        errdefer list.deinit();
-        const writer = list.writer();
+        var list = std.ArrayList(u8).empty;
+        errdefer list.deinit(allocator);
+        const writer = list.writer(allocator);
 
         try writer.print("[{s}] {d}: {s}", .{ self.provider, self.status_code, self.message });
 
@@ -67,7 +67,7 @@ pub const ApiErrorDetails = struct {
             try writer.print(" [retry_after: {d}s]", .{seconds});
         }
 
-        return list.toOwnedSlice();
+        return list.toOwnedSlice(allocator);
     }
 
     /// Parse a Retry-After header value (seconds or HTTP-date).

--- a/packages/provider/src/errors/get-error-message.zig
+++ b/packages/provider/src/errors/get-error-message.zig
@@ -21,9 +21,9 @@ pub fn getErrorMessageOrUnknown(err: ?anyerror) []const u8 {
 
 /// Format an error with its cause chain
 pub fn formatErrorChain(info: ai_sdk_error.AiSdkErrorInfo, allocator: std.mem.Allocator) ![]const u8 {
-    var list = std.array_list.Managed(u8).init(allocator);
-    errdefer list.deinit();
-    const writer = list.writer();
+    var list = std.ArrayList(u8).empty;
+    errdefer list.deinit(allocator);
+    const writer = list.writer(allocator);
 
     try writer.print("{s}: {s}", .{ info.name(), info.message });
 
@@ -40,7 +40,7 @@ pub fn formatErrorChain(info: ai_sdk_error.AiSdkErrorInfo, allocator: std.mem.Al
         current_cause = cause.cause;
     }
 
-    return list.toOwnedSlice();
+    return list.toOwnedSlice(allocator);
 }
 
 test "getErrorMessage" {

--- a/packages/provider/src/errors/json-parse-error.zig
+++ b/packages/provider/src/errors/json-parse-error.zig
@@ -56,9 +56,9 @@ pub const JsonParseError = struct {
 
     /// Format the error with context
     pub fn format(self: Self, allocator: std.mem.Allocator) ![]const u8 {
-        var list = std.array_list.Managed(u8).init(allocator);
-        errdefer list.deinit();
-        const writer = list.writer();
+        var list = std.ArrayList(u8).empty;
+        errdefer list.deinit(allocator);
+        const writer = list.writer(allocator);
 
         try writer.print("JSON parsing failed: {s}\n", .{self.message()});
 
@@ -72,7 +72,7 @@ pub const JsonParseError = struct {
             try writer.writeByte('\n');
         }
 
-        return list.toOwnedSlice();
+        return list.toOwnedSlice(allocator);
     }
 };
 

--- a/packages/provider/src/errors/too-many-embedding-values-for-call-error.zig
+++ b/packages/provider/src/errors/too-many-embedding-values-for-call-error.zig
@@ -87,9 +87,9 @@ pub const TooManyEmbeddingValuesForCallError = struct {
 
     /// Format the error with context
     pub fn format(self: Self, allocator: std.mem.Allocator) ![]const u8 {
-        var list = std.array_list.Managed(u8).init(allocator);
-        errdefer list.deinit();
-        const writer = list.writer();
+        var list = std.ArrayList(u8).empty;
+        errdefer list.deinit(allocator);
+        const writer = list.writer(allocator);
 
         try writer.print(
             "Too many values for a single embedding call. " ++
@@ -103,7 +103,7 @@ pub const TooManyEmbeddingValuesForCallError = struct {
             },
         );
 
-        return list.toOwnedSlice();
+        return list.toOwnedSlice(allocator);
     }
 };
 

--- a/packages/provider/src/json-value/json-value.zig
+++ b/packages/provider/src/json-value/json-value.zig
@@ -88,10 +88,10 @@ pub const JsonValue = union(enum) {
 
     /// Stringify the JSON value.
     pub fn stringify(self: Self, allocator: std.mem.Allocator) ![]const u8 {
-        var list = std.array_list.Managed(u8).init(allocator);
-        errdefer list.deinit();
-        try self.stringifyTo(list.writer());
-        return list.toOwnedSlice();
+        var list = std.ArrayList(u8).empty;
+        errdefer list.deinit(allocator);
+        try self.stringifyTo(list.writer(allocator));
+        return list.toOwnedSlice(allocator);
     }
 
     /// Write the JSON value to a writer.

--- a/packages/provider/src/shared/v3/shared-v3-headers.zig
+++ b/packages/provider/src/shared/v3/shared-v3-headers.zig
@@ -63,15 +63,15 @@ pub fn mergeHeaders(
 
 /// Convert headers to a slice for HTTP client use
 pub fn headersToSlice(headers: SharedV3Headers, allocator: std.mem.Allocator) ![]const [2][]const u8 {
-    var list = std.array_list.Managed([2][]const u8).init(allocator);
-    errdefer list.deinit();
+    var list = std.ArrayList([2][]const u8).empty;
+    errdefer list.deinit(allocator);
 
     var iter = headers.iterator();
     while (iter.next()) |entry| {
-        try list.append(.{ entry.key_ptr.*, entry.value_ptr.* });
+        try list.append(allocator, .{ entry.key_ptr.*, entry.value_ptr.* });
     }
 
-    return list.toOwnedSlice();
+    return list.toOwnedSlice(allocator);
 }
 
 /// Check if a header exists

--- a/packages/provider/src/shared/v3/shared-v3-warning.zig
+++ b/packages/provider/src/shared/v3/shared-v3-warning.zig
@@ -65,9 +65,9 @@ pub const SharedV3Warning = union(enum) {
 
     /// Get a human-readable description of the warning
     pub fn describe(self: SharedV3Warning, allocator: std.mem.Allocator) ![]const u8 {
-        var list = std.array_list.Managed(u8).init(allocator);
-        errdefer list.deinit();
-        const writer = list.writer();
+        var list = std.ArrayList(u8).empty;
+        errdefer list.deinit(allocator);
+        const writer = list.writer(allocator);
 
         switch (self) {
             .unsupported => |w| {
@@ -87,7 +87,7 @@ pub const SharedV3Warning = union(enum) {
             },
         }
 
-        return list.toOwnedSlice();
+        return list.toOwnedSlice(allocator);
     }
 };
 


### PR DESCRIPTION
## Summary
- Replaces all 129 usages of deprecated `std.array_list.Managed(T)` with `std.ArrayList(T)` across 45 files
- `Managed` stored the allocator internally; `ArrayList` requires passing it explicitly to each method call (`.append(allocator, val)`, `.deinit(allocator)`, etc.)
- This aligns with Zig 0.15's design philosophy of explicit allocator usage

Closes #3

## Test plan
- [x] All 1139 tests pass with zero failures
- [x] Zero remaining `std.array_list.Managed` references in codebase
- [x] Build completes cleanly with no compilation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)