### PR TITLE
Use .empty for MockHttpClient ArrayList init

### DIFF
--- a/packages/provider-utils/src/http/mock-client.zig
+++ b/packages/provider-utils/src/http/mock-client.zig
@@ -64,7 +64,7 @@ pub const MockHttpClient = struct {
     pub fn init(allocator: std.mem.Allocator) Self {
         return .{
             .allocator = allocator,
-            .recorded_requests = std.ArrayList(RecordedRequest){},
+            .recorded_requests = std.ArrayList(RecordedRequest).empty,
         };
     }
 


### PR DESCRIPTION
## Summary
- The original bug (Managed without `.init(allocator)`) was fixed by the ArrayList migration in #3
- Changed `std.ArrayList(RecordedRequest){}` to `.empty` for idiomatic consistency

## Test plan
- [x] All tests pass

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)