### PR TITLE
Clarify buffer growth check in EventSourceParser

### DIFF
--- a/packages/provider-utils/src/parse-json-event-stream.zig
+++ b/packages/provider-utils/src/parse-json-event-stream.zig
@@ -65,7 +65,8 @@ pub const EventSourceParser = struct {
         on_event: *const fn (ctx: ?*anyopaque, event: Event) void,
         ctx: ?*anyopaque,
     ) !void {
-        // Check buffer size limit before appending
+        // Check projected buffer size before appending to avoid unnecessary allocation.
+        // Uses current + incoming to catch large chunks that would exceed the limit.
         if (self.max_buffer_size) |max_size| {
             if (self.buffer.items.len + data.len > max_size) {
                 return error.BufferLimitExceeded;


### PR DESCRIPTION
## Summary
- The pre-append buffer check (`current + incoming > max`) is already correct - it catches large chunks that would exceed the limit
- Improved the comment to document the projected-size approach
- Existing test `rejects event stream exceeding buffer limit` already verifies this behavior

## Test plan
- [x] All tests pass
- [x] Existing buffer limit test verifies correct behavior

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)