### PR TITLE
Accumulate stream usage on finish instead of overwriting

### DIFF
--- a/packages/ai/src/generate-text/stream-text.zig
+++ b/packages/ai/src/generate-text/stream-text.zig
@@ -250,7 +250,7 @@ pub const StreamTextResult = struct {
             .finish => |finish| {
                 self.finish_reason = finish.finish_reason;
                 self.usage = finish.usage;
-                self.total_usage = finish.total_usage;
+                self.total_usage = self.total_usage.add(finish.usage);
                 self.is_complete = true;
             },
             else => {},


### PR DESCRIPTION
## Summary
- The `.finish` event handler was overwriting `total_usage` with the finish event's value, discarding previously accumulated usage from `step_finish` events
- Changed to use `.add()` to accumulate, matching the `step_finish` pattern

## Test plan
- [x] All tests pass

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)