### PR TITLE
fix(ai): clarify std.json.Stringify.valueAlloc usage

### DIFF
--- a/packages/ai/src/generate-object/generate-object.zig
+++ b/packages/ai/src/generate-object/generate-object.zig
@@ -144,7 +144,7 @@ pub fn generateObject(
 
     writer.writeAll("You must respond with a valid JSON object matching the following schema:\n") catch return GenerateObjectError.OutOfMemory;
 
-    // Serialize schema using valueAlloc
+    // Serialize schema to JSON string (std.json.Stringify.valueAlloc exists in Zig 0.15+)
     const schema_json = std.json.Stringify.valueAlloc(arena_allocator, options.schema.json_schema, .{}) catch return GenerateObjectError.OutOfMemory;
     writer.writeAll(schema_json) catch return GenerateObjectError.OutOfMemory;
 


### PR DESCRIPTION
## Summary
- Verified `std.json.Stringify.valueAlloc` exists in Zig 0.15.2 (false positive from review)
- Updated comment in generate-object.zig to document the API is available in Zig 0.15+

Closes #14

## Test plan
- [x] `zig build test` passes (no functional change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)