### PR TITLE
feat: add error_diagnostic to all CallOptions and API Options

### DIFF
--- a/packages/ai/src/embed/embed.zig
+++ b/packages/ai/src/embed/embed.zig
@@ -96,6 +96,9 @@ pub const EmbedOptions = struct {
 
     /// Retry policy for automatic retries
     retry_policy: ?@import("../retry.zig").RetryPolicy = null,
+
+    /// Error diagnostic out-parameter for rich error context on failure.
+    error_diagnostic: ?*provider_types.ErrorDiagnostic = null,
 };
 
 /// Options for embedMany
@@ -117,6 +120,9 @@ pub const EmbedManyOptions = struct {
 
     /// Retry policy for automatic retries
     retry_policy: ?@import("../retry.zig").RetryPolicy = null,
+
+    /// Error diagnostic out-parameter for rich error context on failure.
+    error_diagnostic: ?*provider_types.ErrorDiagnostic = null,
 };
 
 /// Error types for embedding

--- a/packages/ai/src/generate-image/generate-image.zig
+++ b/packages/ai/src/generate-image/generate-image.zig
@@ -147,6 +147,9 @@ pub const GenerateImageOptions = struct {
 
     /// Retry policy for automatic retries
     retry_policy: ?@import("../retry.zig").RetryPolicy = null,
+
+    /// Error diagnostic out-parameter for rich error context on failure.
+    error_diagnostic: ?*provider_types.ErrorDiagnostic = null,
 };
 
 /// Error types for image generation

--- a/packages/ai/src/generate-object/generate-object.zig
+++ b/packages/ai/src/generate-object/generate-object.zig
@@ -97,6 +97,9 @@ pub const GenerateObjectOptions = struct {
 
     /// Retry policy for automatic retries
     retry_policy: ?@import("../retry.zig").RetryPolicy = null,
+
+    /// Error diagnostic out-parameter for rich error context on failure.
+    error_diagnostic: ?*provider_types.ErrorDiagnostic = null,
 };
 
 /// Error types for object generation

--- a/packages/ai/src/generate-speech/generate-speech.zig
+++ b/packages/ai/src/generate-speech/generate-speech.zig
@@ -129,6 +129,9 @@ pub const GenerateSpeechOptions = struct {
 
     /// Retry policy for automatic retries
     retry_policy: ?@import("../retry.zig").RetryPolicy = null,
+
+    /// Error diagnostic out-parameter for rich error context on failure.
+    error_diagnostic: ?*provider_types.ErrorDiagnostic = null,
 };
 
 /// Error types for speech generation

--- a/packages/ai/src/generate-text/generate-text.zig
+++ b/packages/ai/src/generate-text/generate-text.zig
@@ -257,6 +257,9 @@ pub const GenerateTextOptions = struct {
 
     /// Retry policy for automatic retries
     retry_policy: ?@import("../retry.zig").RetryPolicy = null,
+
+    /// Error diagnostic out-parameter for rich error context on failure.
+    error_diagnostic: ?*provider_types.ErrorDiagnostic = null,
 };
 
 /// Error types for text generation

--- a/packages/ai/src/generate-text/stream-text.zig
+++ b/packages/ai/src/generate-text/stream-text.zig
@@ -141,6 +141,9 @@ pub const StreamTextOptions = struct {
 
     /// Retry policy for automatic retries
     retry_policy: ?@import("../retry.zig").RetryPolicy = null,
+
+    /// Error diagnostic out-parameter for rich error context on failure.
+    error_diagnostic: ?*provider_types.ErrorDiagnostic = null,
 };
 
 /// Result handle for streaming text generation

--- a/packages/ai/src/transcribe/transcribe.zig
+++ b/packages/ai/src/transcribe/transcribe.zig
@@ -135,6 +135,9 @@ pub const TranscribeOptions = struct {
 
     /// Retry policy for automatic retries
     retry_policy: ?@import("../retry.zig").RetryPolicy = null,
+
+    /// Error diagnostic out-parameter for rich error context on failure.
+    error_diagnostic: ?*provider_types.ErrorDiagnostic = null,
 };
 
 pub const TimestampGranularity = enum {

--- a/packages/provider/src/embedding-model/v3/embedding-model-v3.zig
+++ b/packages/provider/src/embedding-model/v3/embedding-model-v3.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const shared = @import("../../shared/v3/index.zig");
 const json_value = @import("../../json-value/index.zig");
 const EmbeddingModelV3Embedding = @import("embedding-model-v3-embedding.zig").EmbeddingModelV3Embedding;
+const ErrorDiagnostic = @import("../../errors/diagnostic.zig").ErrorDiagnostic;
 
 /// Call options for embedding generation
 pub const EmbeddingModelCallOptions = struct {
@@ -13,6 +14,9 @@ pub const EmbeddingModelCallOptions = struct {
 
     /// Additional HTTP headers to be sent with the request.
     headers: ?shared.SharedV3Headers = null,
+
+    /// Error diagnostic out-parameter for rich error context on failure.
+    error_diagnostic: ?*ErrorDiagnostic = null,
 };
 
 /// Specification for an embedding model that implements version 3.

--- a/packages/provider/src/image-model/v3/image-model-v3-call-options.zig
+++ b/packages/provider/src/image-model/v3/image-model-v3-call-options.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const shared = @import("../../shared/v3/index.zig");
 const ImageModelV3File = @import("image-model-v3-file.zig").ImageModelV3File;
+const ErrorDiagnostic = @import("../../errors/diagnostic.zig").ErrorDiagnostic;
 
 /// Call options for image generation.
 pub const ImageModelV3CallOptions = struct {
@@ -33,6 +34,9 @@ pub const ImageModelV3CallOptions = struct {
 
     /// Additional HTTP headers to be sent with the request.
     headers: ?std.StringHashMap([]const u8) = null,
+
+    /// Error diagnostic out-parameter for rich error context on failure.
+    error_diagnostic: ?*ErrorDiagnostic = null,
 
     /// Image size specification
     pub const ImageSize = struct {

--- a/packages/provider/src/language-model/v3/language-model-v3-call-options.zig
+++ b/packages/provider/src/language-model/v3/language-model-v3-call-options.zig
@@ -5,6 +5,7 @@ const LanguageModelV3Prompt = @import("language-model-v3-prompt.zig").LanguageMo
 const LanguageModelV3FunctionTool = @import("language-model-v3-function-tool.zig").LanguageModelV3FunctionTool;
 const LanguageModelV3ProviderTool = @import("language-model-v3-provider-tool.zig").LanguageModelV3ProviderTool;
 const LanguageModelV3ToolChoice = @import("language-model-v3-tool-choice.zig").LanguageModelV3ToolChoice;
+const ErrorDiagnostic = @import("../../errors/diagnostic.zig").ErrorDiagnostic;
 
 /// Options for calling a language model.
 pub const LanguageModelV3CallOptions = struct {
@@ -62,6 +63,9 @@ pub const LanguageModelV3CallOptions = struct {
 
     /// Additional provider-specific options.
     provider_options: ?shared.SharedV3ProviderOptions = null,
+
+    /// Error diagnostic out-parameter for rich error context on failure.
+    error_diagnostic: ?*ErrorDiagnostic = null,
 
     /// Response format options
     pub const ResponseFormat = union(enum) {

--- a/packages/provider/src/speech-model/v3/speech-model-v3.zig
+++ b/packages/provider/src/speech-model/v3/speech-model-v3.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const shared = @import("../../shared/v3/index.zig");
 const json_value = @import("../../json-value/index.zig");
+const ErrorDiagnostic = @import("../../errors/diagnostic.zig").ErrorDiagnostic;
 
 /// Call options for speech generation
 pub const SpeechModelV3CallOptions = struct {
@@ -29,6 +30,9 @@ pub const SpeechModelV3CallOptions = struct {
 
     /// Additional HTTP headers to be sent with the request.
     headers: ?std.StringHashMap([]const u8) = null,
+
+    /// Error diagnostic out-parameter for rich error context on failure.
+    error_diagnostic: ?*ErrorDiagnostic = null,
 };
 
 /// Speech model specification version 3.

--- a/packages/provider/src/transcription-model/v3/transcription-model-v3.zig
+++ b/packages/provider/src/transcription-model/v3/transcription-model-v3.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const shared = @import("../../shared/v3/index.zig");
 const json_value = @import("../../json-value/index.zig");
+const ErrorDiagnostic = @import("../../errors/diagnostic.zig").ErrorDiagnostic;
 
 /// Call options for transcription
 pub const TranscriptionModelV3CallOptions = struct {
@@ -16,6 +17,9 @@ pub const TranscriptionModelV3CallOptions = struct {
 
     /// Additional HTTP headers to be sent with the request.
     headers: ?std.StringHashMap([]const u8) = null,
+
+    /// Error diagnostic out-parameter for rich error context on failure.
+    error_diagnostic: ?*ErrorDiagnostic = null,
 
     pub const AudioData = union(enum) {
         binary: []const u8,


### PR DESCRIPTION
## Summary
- Adds `error_diagnostic: ?*ErrorDiagnostic = null` to all 5 provider-level CallOptions structs (language model, embedding, image, speech, transcription)
- Adds the same field to all 8 high-level API Options structs (generateText, streamText, generateObject, embed, embedMany, generateImage, generateSpeech, transcribe)
- Enables opt-in rich error context throughout the SDK pipeline

## Test plan
- [x] All 38 existing tests pass (no regression — new field defaults to `null`)

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)