### PR TITLE
feat: thread error_diagnostic through high-level APIs to providers

### DIFF
--- a/packages/ai/src/embed/embed.zig
+++ b/packages/ai/src/embed/embed.zig
@@ -154,6 +154,7 @@ pub fn embed(
     const values = [_][]const u8{options.value};
     const call_options = provider_types.EmbeddingModelCallOptions{
         .values = &values,
+        .error_diagnostic = options.error_diagnostic,
     };
 
     const CallbackCtx = struct {
@@ -248,6 +249,7 @@ pub fn embedMany(
 
         const call_options = provider_types.EmbeddingModelCallOptions{
             .values = batch,
+            .error_diagnostic = options.error_diagnostic,
         };
 
         const CallbackCtx = struct { result: ?EmbeddingModelV3.EmbedResult = null };

--- a/packages/ai/src/generate-image/generate-image.zig
+++ b/packages/ai/src/generate-image/generate-image.zig
@@ -183,6 +183,7 @@ pub fn generateImage(
         .prompt = options.prompt,
         .n = options.n,
         .seed = if (options.seed) |s| @as(i64, @intCast(s)) else null,
+        .error_diagnostic = options.error_diagnostic,
     };
 
     // Call model.doGenerate

--- a/packages/ai/src/generate-object/generate-object.zig
+++ b/packages/ai/src/generate-object/generate-object.zig
@@ -170,6 +170,7 @@ pub fn generateObject(
         .temperature = if (options.settings.temperature) |t| @as(f32, @floatCast(t)) else null,
         .top_p = if (options.settings.top_p) |t| @as(f32, @floatCast(t)) else null,
         .seed = if (options.settings.seed) |s| @as(i64, @intCast(s)) else null,
+        .error_diagnostic = options.error_diagnostic,
     };
 
     // Call model.doGenerate

--- a/packages/ai/src/generate-speech/generate-speech.zig
+++ b/packages/ai/src/generate-speech/generate-speech.zig
@@ -165,6 +165,7 @@ pub fn generateSpeech(
         .text = options.text,
         .voice = options.voice,
         .speed = if (options.voice_settings.speed) |s| @as(f32, @floatCast(s)) else null,
+        .error_diagnostic = options.error_diagnostic,
     };
 
     // Call model.doGenerate

--- a/packages/ai/src/generate-text/generate-text.zig
+++ b/packages/ai/src/generate-text/generate-text.zig
@@ -358,6 +358,7 @@ pub fn generateText(
             .presence_penalty = if (options.settings.presence_penalty) |p| @as(f32, @floatCast(p)) else null,
             .frequency_penalty = if (options.settings.frequency_penalty) |f| @as(f32, @floatCast(f)) else null,
             .seed = if (options.settings.seed) |s| @as(i64, @intCast(s)) else null,
+            .error_diagnostic = options.error_diagnostic,
         };
 
         // Synchronous callback to capture result

--- a/packages/ai/src/generate-text/stream-text.zig
+++ b/packages/ai/src/generate-text/stream-text.zig
@@ -351,6 +351,7 @@ pub fn streamText(
         .presence_penalty = if (options.settings.presence_penalty) |p| @as(f32, @floatCast(p)) else null,
         .frequency_penalty = if (options.settings.frequency_penalty) |f| @as(f32, @floatCast(f)) else null,
         .seed = if (options.settings.seed) |s| @as(i64, @intCast(s)) else null,
+        .error_diagnostic = options.error_diagnostic,
     };
 
     // Bridge: translate provider-level stream parts to ai-level

--- a/packages/ai/src/transcribe/transcribe.zig
+++ b/packages/ai/src/transcribe/transcribe.zig
@@ -199,6 +199,7 @@ pub fn transcribe(
     const call_options = provider_types.TranscriptionModelV3CallOptions{
         .audio = audio_data,
         .media_type = media_type,
+        .error_diagnostic = options.error_diagnostic,
     };
 
     // Call model.doGenerate


### PR DESCRIPTION
## Summary
- Forwards `error_diagnostic` from all 8 high-level API Options structs to the provider-level CallOptions
- Completes the diagnostic pipeline: caller → high-level API → provider → HTTP layer
- 8 one-line additions across 7 files (embed.zig has 2 call sites)

## Test plan
- [x] All 1122 existing tests pass (no regression)

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)