### PR TITLE
Live provider integration tests and real HTTP client

### DIFF
--- a/packages/anthropic/src/anthropic-messages-language-model.zig
+++ b/packages/anthropic/src/anthropic-messages-language-model.zig
@@ -55,7 +55,7 @@ pub const AnthropicMessagesLanguageModel = struct {
         self: *const Self,
         call_options: lm.LanguageModelV3CallOptions,
         result_allocator: std.mem.Allocator,
-        callback: *const fn (?*anyopaque, GenerateResult) void,
+        callback: *const fn (?*anyopaque, lm.LanguageModelV3.GenerateResult) void,
         context: ?*anyopaque,
     ) void {
         // Use arena for request processing
@@ -734,9 +734,10 @@ const StreamState = struct {
 
 /// Serialize request to JSON
 fn serializeRequest(allocator: std.mem.Allocator, request: api.AnthropicMessagesRequest) ![]const u8 {
-    var buffer = std.ArrayList(u8).empty;
-    try std.json.stringify(request, .{}, buffer.writer(allocator));
-    return buffer.toOwnedSlice(allocator);
+    var out: std.io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+    try std.json.Stringify.value(request, .{}, &out.writer);
+    return out.toOwnedSlice();
 }
 
 test "AnthropicMessagesLanguageModel basic" {

--- a/packages/google-vertex/src/google-vertex-embedding-model.zig
+++ b/packages/google-vertex/src/google-vertex-embedding-model.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
-const embedding = @import("../../provider/src/embedding-model/v3/index.zig");
-const shared = @import("../../provider/src/shared/v3/index.zig");
+const embedding = @import("provider").embedding_model;
+const shared = @import("provider").shared;
 const provider_utils = @import("provider-utils");
 
 const config_mod = @import("google-vertex-config.zig");

--- a/packages/google-vertex/src/google-vertex-image-model.zig
+++ b/packages/google-vertex/src/google-vertex-image-model.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
-const image = @import("../../provider/src/image-model/v3/index.zig");
-const shared = @import("../../provider/src/shared/v3/index.zig");
+const image = @import("provider").image_model;
+const shared = @import("provider").shared;
 const provider_utils = @import("provider-utils");
 
 const config_mod = @import("google-vertex-config.zig");

--- a/packages/google-vertex/src/google-vertex-provider.zig
+++ b/packages/google-vertex/src/google-vertex-provider.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const provider_utils = @import("provider-utils");
-const provider_v3 = @import("../../provider/src/provider/v3/index.zig");
-const lm = @import("../../provider/src/language-model/v3/index.zig");
+const provider_v3 = @import("provider").provider;
+const lm = @import("provider").language_model;
 
 const config_mod = @import("google-vertex-config.zig");
 const embed_model = @import("google-vertex-embedding-model.zig");
@@ -9,8 +9,8 @@ const image_model = @import("google-vertex-image-model.zig");
 const options_mod = @import("google-vertex-options.zig");
 
 // Import Google AI language model (Vertex reuses it)
-const google_lang_model = @import("../../google/src/google-generative-ai-language-model.zig");
-const google_config = @import("../../google/src/google-config.zig");
+const google_lang_model = @import("google").lang_model;
+const google_config = @import("google").config;
 
 /// Google Vertex AI Provider settings
 pub const GoogleVertexProviderSettings = struct {

--- a/packages/google/src/google-generative-ai-language-model.zig
+++ b/packages/google/src/google-generative-ai-language-model.zig
@@ -598,16 +598,14 @@ pub const GoogleGenerativeAILanguageModel = struct {
         }
 
         // Add response format
-        if (call_options.response_format) |format| {
-            switch (format) {
-                .json => {
-                    try gen_config.put("responseMimeType", .{ .string = "application/json" });
-                    if (format.json.schema) |schema| {
-                        try gen_config.put("responseSchema", schema);
-                    }
-                },
-                .text => {},
-            }
+        switch (call_options.response_format) {
+            .json => |json_fmt| {
+                try gen_config.put("responseMimeType", .{ .string = "application/json" });
+                if (json_fmt.schema) |schema| {
+                    try gen_config.put("responseSchema", schema);
+                }
+            },
+            .text => {},
         }
 
         if (gen_config.count() > 0) {

--- a/packages/provider-utils/src/http/std-client.zig
+++ b/packages/provider-utils/src/http/std-client.zig
@@ -1,9 +1,10 @@
 const std = @import("std");
 const client_mod = @import("client.zig");
 
-/// HTTP client implementation using Zig's standard library.
-/// NOTE: This is a stub implementation - the Zig 0.15 HTTP API has changed significantly.
-/// For production use, implement a proper HTTP client.
+/// HTTP client implementation using Zig 0.15's standard library `std.http.Client`.
+///
+/// Supports both one-shot (non-streaming) and streaming requests over HTTP/HTTPS
+/// with automatic TLS certificate handling.
 pub const StdHttpClient = struct {
     allocator: std.mem.Allocator,
 
@@ -35,6 +36,76 @@ pub const StdHttpClient = struct {
         .cancel = null,
     };
 
+    /// Map our Method enum to std.http.Method
+    fn mapMethod(method: client_mod.HttpClient.Method) std.http.Method {
+        return switch (method) {
+            .GET => .GET,
+            .POST => .POST,
+            .PUT => .PUT,
+            .DELETE => .DELETE,
+            .PATCH => .PATCH,
+            .HEAD => .HEAD,
+            .OPTIONS => .OPTIONS,
+        };
+    }
+
+    /// Build extra_headers array from our Header slice.
+    /// Returns a slice of std.http.Header pointing into the original data.
+    fn buildExtraHeaders(
+        headers: []const client_mod.HttpClient.Header,
+        buf: []std.http.Header,
+    ) []const std.http.Header {
+        var count: usize = 0;
+        for (headers) |h| {
+            // Skip standard headers that std.http.Client handles via .headers
+            if (std.ascii.eqlIgnoreCase(h.name, "host")) continue;
+            if (std.ascii.eqlIgnoreCase(h.name, "user-agent")) continue;
+            if (std.ascii.eqlIgnoreCase(h.name, "connection")) continue;
+            if (std.ascii.eqlIgnoreCase(h.name, "accept-encoding")) continue;
+            if (std.ascii.eqlIgnoreCase(h.name, "content-type")) continue;
+            if (std.ascii.eqlIgnoreCase(h.name, "authorization")) continue;
+            if (count >= buf.len) break;
+            buf[count] = .{ .name = h.name, .value = h.value };
+            count += 1;
+        }
+        return buf[0..count];
+    }
+
+    /// Extract content-type header override if present
+    fn getContentType(headers: []const client_mod.HttpClient.Header) std.http.Client.Request.Headers.Value {
+        for (headers) |h| {
+            if (std.ascii.eqlIgnoreCase(h.name, "content-type")) {
+                return .{ .override = h.value };
+            }
+        }
+        return .default;
+    }
+
+    /// Extract authorization header override if present
+    fn getAuthorization(headers: []const client_mod.HttpClient.Header) std.http.Client.Request.Headers.Value {
+        for (headers) |h| {
+            if (std.ascii.eqlIgnoreCase(h.name, "authorization")) {
+                return .{ .override = h.value };
+            }
+        }
+        return .default;
+    }
+
+    /// Collect response headers from the raw head bytes into caller-allocated buffer
+    fn collectHeaders(
+        head: std.http.Client.Response.Head,
+        header_buf: []client_mod.HttpClient.Header,
+    ) []const client_mod.HttpClient.Header {
+        var count: usize = 0;
+        var it = head.iterateHeaders();
+        while (it.next()) |h| {
+            if (count >= header_buf.len) break;
+            header_buf[count] = .{ .name = h.name, .value = h.value };
+            count += 1;
+        }
+        return header_buf[0..count];
+    }
+
     fn doRequest(
         impl: *anyopaque,
         req: client_mod.HttpClient.Request,
@@ -43,14 +114,46 @@ pub const StdHttpClient = struct {
         on_error: *const fn (ctx: ?*anyopaque, err: client_mod.HttpClient.HttpError) void,
         ctx: ?*anyopaque,
     ) void {
-        _ = impl;
-        _ = req;
-        _ = allocator;
-        _ = on_response;
-        // Stub: return an error indicating HTTP client not implemented
-        on_error(ctx, .{
-            .kind = .unknown,
-            .message = "StdHttpClient not implemented for Zig 0.15",
+        const self: *Self = @ptrCast(@alignCast(impl));
+
+        // Create std.http.Client using the client's own allocator (not the arena)
+        var http_client: std.http.Client = .{ .allocator = self.allocator };
+        defer http_client.deinit();
+
+        // Build extra headers (exclude standard ones handled by std.http.Client)
+        var extra_header_buf: [client_mod.HttpClient.max_header_count]std.http.Header = undefined;
+        const extra_headers = buildExtraHeaders(req.headers, &extra_header_buf);
+
+        // Create response body writer
+        var response_body: std.Io.Writer.Allocating = .init(allocator);
+        defer response_body.deinit();
+
+        // Perform the fetch
+        const result = http_client.fetch(.{
+            .location = .{ .url = req.url },
+            .method = mapMethod(req.method),
+            .payload = req.body,
+            .extra_headers = extra_headers,
+            .headers = .{
+                .content_type = getContentType(req.headers),
+                .authorization = getAuthorization(req.headers),
+            },
+            .response_writer = &response_body.writer,
+        }) catch |err| {
+            on_error(ctx, .{
+                .kind = mapFetchError(err),
+                .message = @errorName(err),
+            });
+            return;
+        };
+
+        const status_code = @intFromEnum(result.status);
+        const body = response_body.written();
+
+        on_response(ctx, .{
+            .status_code = status_code,
+            .headers = &.{},
+            .body = body,
         });
     }
 
@@ -60,14 +163,164 @@ pub const StdHttpClient = struct {
         allocator: std.mem.Allocator,
         callbacks: client_mod.HttpClient.StreamCallbacks,
     ) void {
-        _ = impl;
-        _ = req;
+        const self: *Self = @ptrCast(@alignCast(impl));
         _ = allocator;
-        // Stub: return an error indicating HTTP client not implemented
-        callbacks.on_error(callbacks.ctx, .{
-            .kind = .unknown,
-            .message = "StdHttpClient streaming not implemented for Zig 0.15",
-        });
+
+        // Create std.http.Client
+        var http_client: std.http.Client = .{ .allocator = self.allocator };
+        defer http_client.deinit();
+
+        // Parse URI
+        const uri = std.Uri.parse(req.url) catch {
+            callbacks.on_error(callbacks.ctx, .{
+                .kind = .invalid_response,
+                .message = "Failed to parse URL",
+            });
+            return;
+        };
+
+        // Build extra headers
+        var extra_header_buf: [client_mod.HttpClient.max_header_count]std.http.Header = undefined;
+        const extra_headers = buildExtraHeaders(req.headers, &extra_header_buf);
+
+        // Open request
+        var http_req = http_client.request(mapMethod(req.method), uri, .{
+            .extra_headers = extra_headers,
+            .headers = .{
+                .content_type = getContentType(req.headers),
+                .authorization = getAuthorization(req.headers),
+            },
+            .keep_alive = false,
+        }) catch {
+            callbacks.on_error(callbacks.ctx, .{
+                .kind = .connection_failed,
+                .message = "Failed to open connection",
+            });
+            return;
+        };
+        defer http_req.deinit();
+
+        // Send body if present
+        if (req.body) |body| {
+            http_req.transfer_encoding = .{ .content_length = body.len };
+            var bw = http_req.sendBodyUnflushed(&.{}) catch {
+                callbacks.on_error(callbacks.ctx, .{
+                    .kind = .connection_failed,
+                    .message = "Failed to send request head",
+                });
+                return;
+            };
+            bw.writer.writeAll(body) catch {
+                callbacks.on_error(callbacks.ctx, .{
+                    .kind = .connection_failed,
+                    .message = "Failed to write request body",
+                });
+                return;
+            };
+            bw.end() catch {
+                callbacks.on_error(callbacks.ctx, .{
+                    .kind = .connection_failed,
+                    .message = "Failed to end request body",
+                });
+                return;
+            };
+            http_req.connection.?.flush() catch {
+                callbacks.on_error(callbacks.ctx, .{
+                    .kind = .connection_failed,
+                    .message = "Failed to flush connection",
+                });
+                return;
+            };
+        } else {
+            http_req.sendBodiless() catch {
+                callbacks.on_error(callbacks.ctx, .{
+                    .kind = .connection_failed,
+                    .message = "Failed to send bodiless request",
+                });
+                return;
+            };
+        }
+
+        // Receive response head
+        var redirect_buf: [0]u8 = .{};
+        var response = http_req.receiveHead(&redirect_buf) catch {
+            callbacks.on_error(callbacks.ctx, .{
+                .kind = .connection_failed,
+                .message = "Failed to receive response headers",
+            });
+            return;
+        };
+
+        const status_code = @intFromEnum(response.head.status);
+
+        // Report headers
+        if (callbacks.on_headers) |on_headers| {
+            var header_buf: [client_mod.HttpClient.max_header_count]client_mod.HttpClient.Header = undefined;
+            const resp_headers = collectHeaders(response.head, &header_buf);
+            on_headers(callbacks.ctx, status_code, resp_headers);
+        }
+
+        // Read response body in chunks
+        var transfer_buf: [8192]u8 = undefined;
+        var chunk_reader = response.reader(&transfer_buf);
+
+        var read_buf: [8192]u8 = undefined;
+        while (true) {
+            var write_target = std.Io.Writer.fixed(&read_buf);
+            const n = chunk_reader.stream(&write_target, .unlimited) catch |err| switch (err) {
+                error.EndOfStream => break,
+                error.ReadFailed => {
+                    callbacks.on_error(callbacks.ctx, .{
+                        .kind = .connection_failed,
+                        .message = "Failed to read response body",
+                    });
+                    return;
+                },
+                error.WriteFailed => {
+                    // Buffer full - deliver what we have and reset
+                    callbacks.on_chunk(callbacks.ctx, &read_buf);
+                    continue;
+                },
+            };
+            if (n == 0) continue;
+            callbacks.on_chunk(callbacks.ctx, read_buf[0..n]);
+        }
+
+        // Deliver any remaining buffered data from the reader
+        const remaining = chunk_reader.buffered();
+        if (remaining.len > 0) {
+            callbacks.on_chunk(callbacks.ctx, remaining);
+        }
+
+        callbacks.on_complete(callbacks.ctx);
+    }
+
+    /// Map fetch errors to our error kinds
+    fn mapFetchError(err: std.http.Client.FetchError) client_mod.HttpClient.HttpError.ErrorKind {
+        return switch (err) {
+            error.ConnectionRefused,
+            error.ConnectionTimedOut,
+            error.NetworkUnreachable,
+            error.ConnectionResetByPeer,
+            => .connection_failed,
+
+            error.TlsInitializationFailed,
+            error.CertificateBundleLoadFailure,
+            => .ssl_error,
+
+            error.HttpRedirectLocationOversize,
+            error.TooManyHttpRedirects,
+            error.RedirectRequiresResend,
+            => .too_many_redirects,
+
+            error.StreamTooLong => .response_too_large,
+
+            error.WriteFailed, error.ReadFailed => .connection_failed,
+
+            error.UnsupportedCompressionMethod => .invalid_response,
+
+            else => .unknown,
+        };
     }
 };
 

--- a/tests/integration/live_provider_test.zig
+++ b/tests/integration/live_provider_test.zig
@@ -1,0 +1,373 @@
+const std = @import("std");
+const testing = std.testing;
+const ai = @import("ai");
+const provider_types = @import("provider");
+const provider_utils = @import("provider-utils");
+const GenerateTextError = ai.generate_text.GenerateTextError;
+
+// Provider imports
+const openai = @import("openai");
+const azure = @import("azure");
+const xai = @import("xai");
+
+// NOTE: Anthropic, Google, and Google Vertex are excluded from live tests
+// because their vtable code paths contain latent compilation bugs:
+// - Anthropic: serializeRequest uses non-existent std.json.stringify,
+//   JsonValue/[]const u8 type mismatch, missing postStream method
+// - Google: std.json.stringify usage, std.json.Value vs JsonValue mismatch
+// - Google Vertex: reuses Google language model, inherits same issues
+// These need separate fixes to their serialization/streaming code.
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn getEnv(name: []const u8) ?[]const u8 {
+    const val = std.posix.getenv(name) orelse return null;
+    if (val.len == 0) return null;
+    return val;
+}
+
+/// Stream context that collects text deltas and tracks completion.
+const StreamTestCtx = struct {
+    text: std.ArrayList(u8),
+    completed: bool = false,
+    had_error: bool = false,
+
+    fn init(_: std.mem.Allocator) StreamTestCtx {
+        return .{ .text = std.ArrayList(u8).empty, .completed = false, .had_error = false };
+    }
+
+    fn deinit(self: *StreamTestCtx, allocator: std.mem.Allocator) void {
+        self.text.deinit(allocator);
+    }
+
+    fn onPart(part: ai.StreamPart, ctx: ?*anyopaque) void {
+        const self: *StreamTestCtx = @ptrCast(@alignCast(ctx.?));
+        switch (part) {
+            .text_delta => |delta| {
+                self.text.appendSlice(testing.allocator, delta.text) catch {};
+            },
+            .finish => {
+                self.completed = true;
+            },
+            else => {},
+        }
+    }
+
+    fn onError(_: anyerror, ctx: ?*anyopaque) void {
+        const self: *StreamTestCtx = @ptrCast(@alignCast(ctx.?));
+        self.had_error = true;
+    }
+
+    fn onComplete(ctx: ?*anyopaque) void {
+        const self: *StreamTestCtx = @ptrCast(@alignCast(ctx.?));
+        self.completed = true;
+    }
+};
+
+// ============================================================================
+// OpenAI
+// ============================================================================
+
+test "live: OpenAI generateText" {
+    const api_key = getEnv("OPENAI_API_KEY") orelse return;
+    const allocator = testing.allocator;
+
+    var http_client = provider_utils.createStdHttpClient(allocator);
+    defer http_client.deinit();
+
+    var provider = openai.createOpenAIWithSettings(allocator, .{
+        .api_key = api_key,
+        .http_client = http_client.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.languageModel("gpt-4o-mini");
+    var lm = model.asLanguageModel();
+    var result = try ai.generateText(allocator, .{
+        .model = &lm,
+        .prompt = "Say hello in one word.",
+    });
+    defer result.deinit(allocator);
+
+    try testing.expect(result.text.len > 0);
+    try testing.expect(result.finish_reason == .stop);
+    try testing.expect(result.usage.input_tokens != null);
+    try testing.expect(result.usage.output_tokens != null);
+}
+
+test "live: OpenAI streamText" {
+    const api_key = getEnv("OPENAI_API_KEY") orelse return;
+    const allocator = testing.allocator;
+
+    var http_client = provider_utils.createStdHttpClient(allocator);
+    defer http_client.deinit();
+
+    var provider = openai.createOpenAIWithSettings(allocator, .{
+        .api_key = api_key,
+        .http_client = http_client.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.languageModel("gpt-4o-mini");
+    var lm = model.asLanguageModel();
+
+    var ctx = StreamTestCtx.init(allocator);
+    defer ctx.deinit(allocator);
+
+    var stream_result = try ai.streamText(allocator, .{
+        .model = &lm,
+        .prompt = "Say hello in one word.",
+        .callbacks = .{
+            .on_part = StreamTestCtx.onPart,
+            .on_error = StreamTestCtx.onError,
+            .on_complete = StreamTestCtx.onComplete,
+            .context = @ptrCast(&ctx),
+        },
+    });
+    defer {
+        stream_result.deinit();
+        allocator.destroy(stream_result);
+    }
+
+    try testing.expect(ctx.completed);
+    try testing.expect(ctx.text.items.len > 0);
+    try testing.expect(!ctx.had_error);
+}
+
+test "live: OpenAI error diagnostic on invalid key" {
+    const allocator = testing.allocator;
+    _ = getEnv("OPENAI_API_KEY") orelse return;
+
+    var http_client = provider_utils.createStdHttpClient(allocator);
+    defer http_client.deinit();
+
+    var provider = openai.createOpenAIWithSettings(allocator, .{
+        .api_key = "sk-invalid-key-for-testing",
+        .http_client = http_client.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.languageModel("gpt-4o-mini");
+    var lm = model.asLanguageModel();
+    var diag: provider_types.ErrorDiagnostic = .{};
+
+    const result = ai.generateText(allocator, .{
+        .model = &lm,
+        .prompt = "Hello",
+        .error_diagnostic = &diag,
+    });
+
+    try testing.expectError(GenerateTextError.ModelError, result);
+    try testing.expect(diag.kind == .authentication);
+    try testing.expect(diag.message() != null);
+    try testing.expect(diag.status_code != null);
+}
+
+// ============================================================================
+// Azure OpenAI
+// ============================================================================
+
+test "live: Azure generateText" {
+    const api_key = getEnv("AZURE_API_KEY") orelse return;
+    const resource_name = getEnv("AZURE_RESOURCE_NAME") orelse return;
+    const deployment_name = getEnv("AZURE_DEPLOYMENT_NAME") orelse return;
+    const allocator = testing.allocator;
+
+    var http_client = provider_utils.createStdHttpClient(allocator);
+    defer http_client.deinit();
+
+    var provider = azure.createAzureWithSettings(allocator, .{
+        .api_key = api_key,
+        .resource_name = resource_name,
+        .http_client = http_client.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.chat(deployment_name);
+    var lm = model.asLanguageModel();
+    var result = try ai.generateText(allocator, .{
+        .model = &lm,
+        .prompt = "Say hello in one word.",
+    });
+    defer result.deinit(allocator);
+
+    try testing.expect(result.text.len > 0);
+    try testing.expect(result.finish_reason == .stop);
+    try testing.expect(result.usage.input_tokens != null);
+    try testing.expect(result.usage.output_tokens != null);
+}
+
+test "live: Azure streamText" {
+    const api_key = getEnv("AZURE_API_KEY") orelse return;
+    const resource_name = getEnv("AZURE_RESOURCE_NAME") orelse return;
+    const deployment_name = getEnv("AZURE_DEPLOYMENT_NAME") orelse return;
+    const allocator = testing.allocator;
+
+    var http_client = provider_utils.createStdHttpClient(allocator);
+    defer http_client.deinit();
+
+    var provider = azure.createAzureWithSettings(allocator, .{
+        .api_key = api_key,
+        .resource_name = resource_name,
+        .http_client = http_client.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.chat(deployment_name);
+    var lm = model.asLanguageModel();
+
+    var ctx = StreamTestCtx.init(allocator);
+    defer ctx.deinit(allocator);
+
+    var stream_result = try ai.streamText(allocator, .{
+        .model = &lm,
+        .prompt = "Say hello in one word.",
+        .callbacks = .{
+            .on_part = StreamTestCtx.onPart,
+            .on_error = StreamTestCtx.onError,
+            .on_complete = StreamTestCtx.onComplete,
+            .context = @ptrCast(&ctx),
+        },
+    });
+    defer {
+        stream_result.deinit();
+        allocator.destroy(stream_result);
+    }
+
+    try testing.expect(ctx.completed);
+    try testing.expect(ctx.text.items.len > 0);
+    try testing.expect(!ctx.had_error);
+}
+
+test "live: Azure error diagnostic on invalid key" {
+    const allocator = testing.allocator;
+    _ = getEnv("AZURE_API_KEY") orelse return;
+    const resource_name = getEnv("AZURE_RESOURCE_NAME") orelse return;
+    const deployment_name = getEnv("AZURE_DEPLOYMENT_NAME") orelse return;
+
+    var http_client = provider_utils.createStdHttpClient(allocator);
+    defer http_client.deinit();
+
+    var provider = azure.createAzureWithSettings(allocator, .{
+        .api_key = "invalid-azure-key",
+        .resource_name = resource_name,
+        .http_client = http_client.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.chat(deployment_name);
+    var lm = model.asLanguageModel();
+    var diag: provider_types.ErrorDiagnostic = .{};
+
+    const result = ai.generateText(allocator, .{
+        .model = &lm,
+        .prompt = "Hello",
+        .error_diagnostic = &diag,
+    });
+
+    try testing.expectError(GenerateTextError.ModelError, result);
+    try testing.expect(diag.kind == .authentication or diag.kind == .invalid_request);
+    try testing.expect(diag.message() != null);
+    try testing.expect(diag.status_code != null);
+}
+
+// ============================================================================
+// xAI
+// ============================================================================
+
+test "live: xAI generateText" {
+    const api_key = getEnv("XAI_API_KEY") orelse return;
+    const allocator = testing.allocator;
+
+    var http_client = provider_utils.createStdHttpClient(allocator);
+    defer http_client.deinit();
+
+    var provider = xai.createXaiWithSettings(allocator, .{
+        .api_key = api_key,
+        .http_client = http_client.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.languageModel("grok-2");
+    var lm = model.asLanguageModel();
+    var result = try ai.generateText(allocator, .{
+        .model = &lm,
+        .prompt = "Say hello in one word.",
+    });
+    defer result.deinit(allocator);
+
+    try testing.expect(result.text.len > 0);
+    try testing.expect(result.finish_reason == .stop);
+    try testing.expect(result.usage.input_tokens != null);
+    try testing.expect(result.usage.output_tokens != null);
+}
+
+test "live: xAI streamText" {
+    const api_key = getEnv("XAI_API_KEY") orelse return;
+    const allocator = testing.allocator;
+
+    var http_client = provider_utils.createStdHttpClient(allocator);
+    defer http_client.deinit();
+
+    var provider = xai.createXaiWithSettings(allocator, .{
+        .api_key = api_key,
+        .http_client = http_client.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.languageModel("grok-2");
+    var lm = model.asLanguageModel();
+
+    var ctx = StreamTestCtx.init(allocator);
+    defer ctx.deinit(allocator);
+
+    var stream_result = try ai.streamText(allocator, .{
+        .model = &lm,
+        .prompt = "Say hello in one word.",
+        .callbacks = .{
+            .on_part = StreamTestCtx.onPart,
+            .on_error = StreamTestCtx.onError,
+            .on_complete = StreamTestCtx.onComplete,
+            .context = @ptrCast(&ctx),
+        },
+    });
+    defer {
+        stream_result.deinit();
+        allocator.destroy(stream_result);
+    }
+
+    try testing.expect(ctx.completed);
+    try testing.expect(ctx.text.items.len > 0);
+    try testing.expect(!ctx.had_error);
+}
+
+test "live: xAI error diagnostic on invalid key" {
+    const allocator = testing.allocator;
+    _ = getEnv("XAI_API_KEY") orelse return;
+
+    var http_client = provider_utils.createStdHttpClient(allocator);
+    defer http_client.deinit();
+
+    var provider = xai.createXaiWithSettings(allocator, .{
+        .api_key = "xai-invalid-key",
+        .http_client = http_client.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.languageModel("grok-2");
+    var lm = model.asLanguageModel();
+    var diag: provider_types.ErrorDiagnostic = .{};
+
+    const result = ai.generateText(allocator, .{
+        .model = &lm,
+        .prompt = "Hello",
+        .error_diagnostic = &diag,
+    });
+
+    try testing.expectError(GenerateTextError.ModelError, result);
+    try testing.expect(diag.kind == .authentication);
+    try testing.expect(diag.message() != null);
+    try testing.expect(diag.status_code != null);
+}


### PR DESCRIPTION
## Summary
- Implement real `StdHttpClient` using Zig 0.15's `std.http.Client` with full TLS/HTTPS support, replacing the previous stub
- Add `zig build test-live` step with 9 integration tests (OpenAI, Azure, xAI x generateText/streamText/error-diagnostic) that skip gracefully when API keys are absent
- Fix google-vertex relative path imports, anthropic vtable type mismatch, and google response_format handling

## Test plan
- [x] `zig build test` passes (all existing unit tests, no regression)
- [x] `zig build test-live` compiles and all 9 tests skip gracefully without env vars
- [ ] `zig build test-live` with `OPENAI_API_KEY` set: 3 OpenAI tests pass
- [ ] `zig build test-live` with `AZURE_API_KEY`/`AZURE_RESOURCE_NAME`/`AZURE_DEPLOYMENT_NAME` set: 3 Azure tests pass
- [ ] `zig build test-live` with `XAI_API_KEY` set: 3 xAI tests pass

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)