### PR TITLE
Audit: memory fixes, core utility tests, mock-HTTP provider tests

### DIFF
--- a/packages/provider-utils/src/combine-headers.zig
+++ b/packages/provider-utils/src/combine-headers.zig
@@ -96,7 +96,10 @@ pub fn combineHeadersWithContentType(
     });
 }
 
-/// Add authorization header to existing headers
+/// Add authorization header to existing headers.
+/// Caller owns the returned slice (free with `allocator.free(result)`).
+/// The Authorization header's value is heap-allocated via `allocPrint`;
+/// caller must also free it (see `addBearerToken` test for cleanup pattern).
 pub fn addAuthorizationHeader(
     allocator: std.mem.Allocator,
     existing_headers: ?[]const http_client.HttpClient.Header,
@@ -115,7 +118,8 @@ pub fn addAuthorizationHeader(
     });
 }
 
-/// Add bearer token authorization
+/// Add bearer token authorization.
+/// Caller owns the returned slice and the Authorization header's value (heap-allocated).
 pub fn addBearerToken(
     allocator: std.mem.Allocator,
     existing_headers: ?[]const http_client.HttpClient.Header,

--- a/packages/provider-utils/src/parse-json-event-stream.zig
+++ b/packages/provider-utils/src/parse-json-event-stream.zig
@@ -238,8 +238,10 @@ pub fn JsonEventStreamParser(comptime T: type) type {
 
             switch (parse_result) {
                 .success => |parsed| {
-                    // In a full implementation, you'd convert parsed to T
-                    _ = parsed;
+                    // TODO: In a full implementation, convert parsed JsonValue to T.
+                    // Free the parsed value to prevent memory leak.
+                    var val = parsed;
+                    val.deinit(self.allocator);
                     self.on_event(self.ctx, .{
                         .failure = .{
                             .message = "Type conversion not implemented",


### PR DESCRIPTION
## Summary
- Fix memory bugs in parse-json-event-stream and combine-headers (Phase 1)
- Add tests for zero-coverage core utilities: post-to-api, response-handler, combine-headers, json-value (Phase 3)
- Add mock-HTTP tests for Anthropic, Azure, Google, xAI using MockHttpClient (Phase 4)

Fixes #58, fixes #59

## Test plan
- [x] `zig build test` passes (0 failures)
- [x] No memory leaks detected by testing.allocator

🤖 Generated with [Claude Code](https://claude.com/claude-code)