### PR TITLE
Fix Anthropic & Google api_key passthrough

### DIFF
--- a/packages/anthropic/src/anthropic-config.zig
+++ b/packages/anthropic/src/anthropic-config.zig
@@ -9,6 +9,9 @@ pub const AnthropicConfig = struct {
     /// Base URL for API calls
     base_url: []const u8,
 
+    /// API key for authenticating requests (preferred over env var)
+    api_key: ?[]const u8 = null,
+
     /// Function to get headers
     headers_fn: *const fn (*const AnthropicConfig, std.mem.Allocator) error{OutOfMemory}!std.StringHashMap([]const u8),
 
@@ -31,7 +34,7 @@ pub const AnthropicConfig = struct {
 };
 
 /// Default Anthropic API version
-pub const anthropic_version = "2024-06-01";
+pub const anthropic_version = "2023-06-01";
 
 /// Default base URL
 pub const default_base_url = "https://api.anthropic.com/v1";

--- a/packages/anthropic/src/anthropic-messages-language-model.zig
+++ b/packages/anthropic/src/anthropic-messages-language-model.zig
@@ -761,7 +761,7 @@ test "AnthropicMessagesLanguageModel basic" {
 }
 
 test "Anthropic API version constant" {
-    try std.testing.expectEqualStrings("2024-06-01", config_mod.anthropic_version);
+    try std.testing.expectEqualStrings("2023-06-01", config_mod.anthropic_version);
 }
 
 test "Anthropic stop reason mapping" {

--- a/packages/anthropic/src/anthropic-provider.zig
+++ b/packages/anthropic/src/anthropic-provider.zig
@@ -48,6 +48,7 @@ pub const AnthropicProvider = struct {
             .config = .{
                 .provider = provider_name,
                 .base_url = base_url,
+                .api_key = settings.api_key,
                 .headers_fn = getHeadersFn,
                 .http_client = settings.http_client,
                 .generate_id = settings.generate_id,
@@ -140,13 +141,13 @@ fn getApiKeyFromEnv() ?[]const u8 {
 
 /// Headers function for config
 fn getHeadersFn(config: *const config_mod.AnthropicConfig, allocator: std.mem.Allocator) error{OutOfMemory}!std.StringHashMap([]const u8) {
-    _ = config;
     var headers = std.StringHashMap([]const u8).init(allocator);
     errdefer headers.deinit();
 
-    // Add API key header
-    if (getApiKeyFromEnv()) |api_key| {
-        try headers.put("x-api-key", api_key);
+    // Add API key header (prefer config, fall back to env var)
+    const api_key = config.api_key orelse getApiKeyFromEnv();
+    if (api_key) |key| {
+        try headers.put("x-api-key", key);
     }
 
     // Add Anthropic version header

--- a/packages/google/src/google-config.zig
+++ b/packages/google/src/google-config.zig
@@ -10,6 +10,9 @@ pub const GoogleGenerativeAIConfig = struct {
     /// Base URL for API calls
     base_url: []const u8 = default_base_url,
 
+    /// API key for authenticating requests (preferred over env var)
+    api_key: ?[]const u8 = null,
+
     /// Function to get headers.
     /// Caller owns the returned HashMap and must call deinit() when done.
     headers_fn: ?*const fn (*const GoogleGenerativeAIConfig, std.mem.Allocator) error{OutOfMemory}!std.StringHashMap([]const u8) = null,

--- a/packages/google/src/google-provider.zig
+++ b/packages/google/src/google-provider.zig
@@ -51,6 +51,7 @@ pub const GoogleGenerativeAIProvider = struct {
             .config = .{
                 .provider = provider_name,
                 .base_url = base_url,
+                .api_key = settings.api_key,
                 .headers_fn = getHeadersFn,
                 .http_client = settings.http_client,
                 .generate_id = settings.generate_id,
@@ -197,13 +198,13 @@ fn getApiKeyFromEnv() ?[]const u8 {
 /// Headers function for config.
 /// Caller owns the returned HashMap and must call deinit() when done.
 fn getHeadersFn(config: *const config_mod.GoogleGenerativeAIConfig, allocator: std.mem.Allocator) error{OutOfMemory}!std.StringHashMap([]const u8) {
-    _ = config;
     var headers = std.StringHashMap([]const u8).init(allocator);
     errdefer headers.deinit();
 
-    // Add API key header
-    if (getApiKeyFromEnv()) |api_key| {
-        try headers.put("x-goog-api-key", api_key);
+    // Add API key header (prefer config, fall back to env var)
+    const api_key = config.api_key orelse getApiKeyFromEnv();
+    if (api_key) |key| {
+        try headers.put("x-goog-api-key", key);
     }
 
     // Add content-type


### PR DESCRIPTION
## Summary
- Add `api_key` field to `AnthropicConfig` and `GoogleGenerativeAIConfig` so keys passed via provider settings flow through to HTTP headers
- Fix `getHeadersFn` in both providers to use `config.api_key orelse getApiKeyFromEnv()` (matching the OpenAI pattern)
- Fix Anthropic API version string from `"2024-06-01"` to `"2023-06-01"`

Closes #64

## Test plan
- [x] All 38 unit test suites pass (`zig build test`)
- [x] 9/10 live tests pass (`zig build test-live`) — remaining failure is pre-existing Anthropic response parser memory leak
- [x] Error diagnostic tests now correctly detect invalid API keys passed via settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)