### PR TITLE
Fix memory leak: add missing parsed.deinit() across providers

### DIFF
--- a/packages/anthropic/src/anthropic-messages-language-model.zig
+++ b/packages/anthropic/src/anthropic-messages-language-model.zig
@@ -240,6 +240,7 @@ pub const AnthropicMessagesLanguageModel = struct {
         const parsed = std.json.parseFromSlice(api.AnthropicMessagesResponse, request_allocator, response_body, .{}) catch {
             return error.InvalidResponse;
         };
+        defer parsed.deinit();
         const response = parsed.value;
 
         // Extract content
@@ -563,6 +564,7 @@ const StreamState = struct {
                     });
                     continue;
                 };
+                defer parsed.deinit();
                 const chunk = parsed.value;
 
                 try self.processAnthropicChunk(chunk, event_type);

--- a/packages/google/src/google-generative-ai-language-model.zig
+++ b/packages/google/src/google-generative-ai-language-model.zig
@@ -341,6 +341,7 @@ pub const GoogleGenerativeAILanguageModel = struct {
                     json_data,
                     .{ .ignore_unknown_fields = true },
                 ) catch return;
+                defer parsed.deinit();
                 const response = parsed.value;
 
                 // Process response

--- a/packages/openai-compatible/src/openai-compatible-chat-language-model.zig
+++ b/packages/openai-compatible/src/openai-compatible-chat-language-model.zig
@@ -215,6 +215,7 @@ pub const OpenAICompatibleChatLanguageModel = struct {
         }) catch {
             return error.InvalidResponse;
         };
+        defer parsed.deinit();
         const response = parsed.value;
 
         // Extract content
@@ -594,6 +595,7 @@ const StreamState = struct {
                 }) catch {
                     continue;
                 };
+                defer parsed.deinit();
                 const chunk = parsed.value;
 
                 // Handle usage

--- a/packages/openai/src/chat/openai-chat-language-model.zig
+++ b/packages/openai/src/chat/openai-chat-language-model.zig
@@ -213,6 +213,7 @@ pub const OpenAIChatLanguageModel = struct {
         }) catch {
             return error.InvalidResponse;
         };
+        defer parsed.deinit();
         const response = parsed.value;
 
         // Extract content
@@ -572,6 +573,7 @@ const StreamState = struct {
                     });
                     continue;
                 };
+                defer parsed.deinit();
                 const chunk = parsed.value;
 
                 // Handle error chunks
@@ -994,6 +996,7 @@ test "OpenAI request serialization - basic" {
 
     // Parse back to verify structure
     const parsed = try std.json.parseFromSlice(std.json.Value, allocator, body, .{});
+    defer parsed.deinit();
 
     const obj = parsed.value.object;
     try std.testing.expectEqualStrings("gpt-4o", obj.get("model").?.string);

--- a/packages/openai/src/embedding/openai-embedding-model.zig
+++ b/packages/openai/src/embedding/openai-embedding-model.zig
@@ -187,6 +187,7 @@ pub const OpenAIEmbeddingModel = struct {
         const parsed = std.json.parseFromSlice(api.OpenAITextEmbeddingResponse, request_allocator, response_body, .{}) catch {
             return error.InvalidResponse;
         };
+        defer parsed.deinit();
         const response = parsed.value;
 
         // Extract embeddings and sort by index

--- a/packages/openai/src/image/openai-image-model.zig
+++ b/packages/openai/src/image/openai-image-model.zig
@@ -181,6 +181,7 @@ pub const OpenAIImageModel = struct {
         const parsed = std.json.parseFromSlice(api.OpenAIImageResponse, request_allocator, response_body, .{}) catch {
             return error.InvalidResponse;
         };
+        defer parsed.deinit();
         const response = parsed.value;
 
         // Extract images as base64

--- a/packages/openai/src/transcription/openai-transcription-model.zig
+++ b/packages/openai/src/transcription/openai-transcription-model.zig
@@ -224,6 +224,7 @@ pub const OpenAITranscriptionModel = struct {
         const parsed = std.json.parseFromSlice(api.OpenAITranscriptionResponse, request_allocator, response_body, .{}) catch {
             return error.InvalidResponse;
         };
+        defer parsed.deinit();
         const response = parsed.value;
 
         // Convert segments to tm.TranscriptionSegment


### PR DESCRIPTION
## Summary
- Add `defer parsed.deinit()` after every `std.json.parseFromSlice` call missing cleanup
- Fixes Anthropic, OpenAI, OpenAI-compatible, and Google providers (both doGenerate and streaming paths)
- 7 files, 11 missing deinit calls fixed

## Test plan
- [x] All 1139 unit tests pass
- [x] Verified all `parseFromSlice` calls across the codebase are now properly cleaned up

Fixes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)