### PR TITLE
Fix Anthropic JSON serialization/parsing for live API

### DIFF
--- a/packages/anthropic/src/anthropic-messages-language-model.zig
+++ b/packages/anthropic/src/anthropic-messages-language-model.zig
@@ -237,7 +237,7 @@ pub const AnthropicMessagesLanguageModel = struct {
         const response_body = http_response.body;
 
         // Parse response
-        const parsed = std.json.parseFromSlice(api.AnthropicMessagesResponse, request_allocator, response_body, .{}) catch {
+        const parsed = std.json.parseFromSlice(api.AnthropicMessagesResponse, request_allocator, response_body, .{ .ignore_unknown_fields = true }) catch {
             return error.InvalidResponse;
         };
         defer parsed.deinit();
@@ -557,7 +557,7 @@ const StreamState = struct {
             } else if (std.mem.startsWith(u8, line, "data: ")) {
                 const json_data = line[6..];
 
-                const parsed = std.json.parseFromSlice(api.AnthropicMessagesChunk, self.result_allocator, json_data, .{}) catch |err| {
+                const parsed = std.json.parseFromSlice(api.AnthropicMessagesChunk, self.result_allocator, json_data, .{ .ignore_unknown_fields = true }) catch |err| {
                     // Report JSON parse error to caller but continue processing subsequent chunks
                     self.callbacks.on_part(self.callbacks.ctx, .{
                         .@"error" = .{ .err = err, .message = "Failed to parse SSE chunk JSON" },
@@ -740,7 +740,7 @@ const StreamState = struct {
 fn serializeRequest(allocator: std.mem.Allocator, request: api.AnthropicMessagesRequest) ![]const u8 {
     var out: std.io.Writer.Allocating = .init(allocator);
     errdefer out.deinit();
-    try std.json.Stringify.value(request, .{}, &out.writer);
+    try std.json.Stringify.value(request, .{ .emit_null_optional_fields = false }, &out.writer);
     return out.toOwnedSlice();
 }
 

--- a/packages/provider/src/json-value/json-value.zig
+++ b/packages/provider/src/json-value/json-value.zig
@@ -89,6 +89,11 @@ pub const JsonValue = union(enum) {
         return fromStdJson(allocator, std_value) catch return error.OutOfMemory;
     }
 
+    /// Custom deserialization from std.json.Value for innerParseFromValue compatibility.
+    pub fn jsonParseFromValue(allocator: std.mem.Allocator, source: std.json.Value, _: std.json.ParseOptions) std.json.ParseFromValueError!Self {
+        return fromStdJson(allocator, source) catch return error.OutOfMemory;
+    }
+
     /// Custom serialization for std.json.Stringify compatibility.
     /// This allows JsonValue to be used in structs serialized by std.json.Stringify.
     pub fn jsonStringify(self: Self, jws: anytype) !void {


### PR DESCRIPTION
## Summary
- Fix request serialization: `union(enum)` types (`MessageContent`, `ToolChoice`) now serialize as flat objects with `"type"` discriminator field instead of Zig's default `{"variant_name": {...}}` wrapper format
- Fix response deserialization: `ContentBlock`, `ContentBlockStart`, `Delta` unions dispatch on `"type"` field via custom `jsonParse`/`jsonParseFromValue`  
- Suppress null optional fields (`emit_null_optional_fields = false`) so `"tool_choice": null` isn't sent to the API
- Add `ignore_unknown_fields = true` on both `parseFromSlice` calls for forward-compatibility with new API fields
- Add `jsonParseFromValue` to `JsonValue` so `std.json.innerParseFromValue` can handle structs containing our custom JSON type

Fixes #75

## Test plan
- [x] All unit tests pass (includes new tests for ContentBlock parsing, MessageContent/ToolChoice serialization)
- [x] All 10 live provider tests pass (OpenAI, Azure, Anthropic, Google, xAI — success + error diagnostic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)