### PR TITLE
Add streamText live tests for all 5 providers

### DIFF
--- a/packages/openai/src/chat/openai-chat-language-model.zig
+++ b/packages/openai/src/chat/openai-chat-language-model.zig
@@ -566,7 +566,9 @@ const StreamState = struct {
                     continue;
                 }
 
-                const parsed = std.json.parseFromSlice(api.OpenAIChatChunk, self.result_allocator, json_data, .{}) catch |err| {
+                const parsed = std.json.parseFromSlice(api.OpenAIChatChunk, self.result_allocator, json_data, .{
+                    .ignore_unknown_fields = true,
+                }) catch |err| {
                     // Report JSON parse error to caller but continue processing subsequent chunks
                     self.callbacks.on_part(self.callbacks.ctx, .{
                         .@"error" = .{ .err = err, .message = "Failed to parse SSE chunk JSON" },

--- a/tests/integration/live_provider_test.zig
+++ b/tests/integration/live_provider_test.zig
@@ -4,6 +4,9 @@ const ai = @import("ai");
 const provider_types = @import("provider");
 const provider_utils = @import("provider-utils");
 const GenerateTextError = ai.generate_text.GenerateTextError;
+const StreamTextError = ai.generate_text.StreamTextError;
+const StreamPart = ai.StreamPart;
+const StreamCallbacks = ai.StreamCallbacks;
 
 // Provider imports
 const openai = @import("openai");
@@ -11,8 +14,6 @@ const azure = @import("azure");
 const anthropic = @import("anthropic");
 const google = @import("google");
 const xai = @import("xai");
-
-// NOTE: streamText tests omitted - doStreamVtable is a stub (#5)
 
 // ============================================================================
 // Helpers
@@ -23,6 +24,57 @@ fn getEnv(name: []const u8) ?[]const u8 {
     if (val.len == 0) return null;
     return val;
 }
+
+/// Test context for collecting streaming results
+const StreamTestCtx = struct {
+    text_buf: std.ArrayList(u8) = std.ArrayList(u8).empty,
+    error_count: u32 = 0,
+    finished: bool = false,
+    completed: bool = false,
+    alloc: std.mem.Allocator,
+
+    fn onPart(part: StreamPart, ctx_raw: ?*anyopaque) void {
+        if (ctx_raw) |p| {
+            const self: *StreamTestCtx = @ptrCast(@alignCast(p));
+            switch (part) {
+                .text_delta => |d| {
+                    self.text_buf.appendSlice(self.alloc, d.text) catch {};
+                },
+                .finish => {
+                    self.finished = true;
+                },
+                else => {},
+            }
+        }
+    }
+
+    fn onError(_: anyerror, ctx_raw: ?*anyopaque) void {
+        if (ctx_raw) |p| {
+            const self: *StreamTestCtx = @ptrCast(@alignCast(p));
+            self.error_count += 1;
+        }
+    }
+
+    fn onComplete(ctx_raw: ?*anyopaque) void {
+        if (ctx_raw) |p| {
+            const self: *StreamTestCtx = @ptrCast(@alignCast(p));
+            self.completed = true;
+        }
+    }
+
+    fn callbacks(self: *StreamTestCtx) StreamCallbacks {
+        return .{
+            .on_part = onPart,
+            .on_error = onError,
+            .on_complete = onComplete,
+            .context = @ptrCast(self),
+        };
+    }
+
+    fn deinit(self: *StreamTestCtx) void {
+        self.text_buf.deinit(self.alloc);
+    }
+};
 
 // ============================================================================
 // OpenAI
@@ -82,6 +134,40 @@ test "live: OpenAI error diagnostic on invalid key" {
     try testing.expect(diag.kind == .authentication);
     try testing.expect(diag.message() != null);
     try testing.expect(diag.status_code != null);
+}
+
+test "live: OpenAI streamText" {
+    const api_key = getEnv("OPENAI_API_KEY") orelse return;
+
+    // Arena for all streaming allocations (providers leak through HTTP client)
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var http_client = provider_utils.createStdHttpClient(alloc);
+    var provider = openai.createOpenAIWithSettings(alloc, .{
+        .api_key = api_key,
+        .http_client = http_client.asInterface(),
+    });
+
+    var model = provider.languageModel("gpt-4o-mini");
+    var lm = model.asLanguageModel();
+
+    var ctx = StreamTestCtx{ .alloc = alloc };
+
+    const stream_result = ai.streamText(alloc, .{
+        .model = &lm,
+        .prompt = "Say hello in one word.",
+        .callbacks = ctx.callbacks(),
+    }) catch |err| {
+        std.debug.print("OpenAI streamText error: {}\n", .{err});
+        return err;
+    };
+
+    try testing.expect(ctx.completed);
+    try testing.expect(ctx.text_buf.items.len > 0);
+    try testing.expect(ctx.error_count == 0);
+    try testing.expect(stream_result.getText().len > 0);
 }
 
 // ============================================================================
@@ -150,6 +236,42 @@ test "live: Azure error diagnostic on invalid key" {
     try testing.expect(diag.status_code != null);
 }
 
+test "live: Azure streamText" {
+    const api_key = getEnv("AZURE_API_KEY") orelse return;
+    const resource_name = getEnv("AZURE_RESOURCE_NAME") orelse return;
+    const deployment_name = getEnv("AZURE_DEPLOYMENT_NAME") orelse return;
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var http_client = provider_utils.createStdHttpClient(alloc);
+    var provider = azure.createAzureWithSettings(alloc, .{
+        .api_key = api_key,
+        .resource_name = resource_name,
+        .http_client = http_client.asInterface(),
+    });
+
+    var model = provider.chat(deployment_name);
+    var lm = model.asLanguageModel();
+
+    var ctx = StreamTestCtx{ .alloc = alloc };
+
+    const stream_result = ai.streamText(alloc, .{
+        .model = &lm,
+        .prompt = "Say hello in one word.",
+        .callbacks = ctx.callbacks(),
+    }) catch |err| {
+        std.debug.print("Azure streamText error: {}\n", .{err});
+        return err;
+    };
+
+    try testing.expect(ctx.completed);
+    try testing.expect(ctx.text_buf.items.len > 0);
+    try testing.expect(ctx.error_count == 0);
+    try testing.expect(stream_result.getText().len > 0);
+}
+
 // ============================================================================
 // Anthropic
 // ============================================================================
@@ -208,6 +330,39 @@ test "live: Anthropic error diagnostic on invalid key" {
     try testing.expect(diag.kind == .authentication);
     try testing.expect(diag.message() != null);
     try testing.expect(diag.status_code != null);
+}
+
+test "live: Anthropic streamText" {
+    const api_key = getEnv("ANTHROPIC_API_KEY") orelse return;
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var http_client = provider_utils.createStdHttpClient(alloc);
+    var provider = anthropic.createAnthropicWithSettings(alloc, .{
+        .api_key = api_key,
+        .http_client = http_client.asInterface(),
+    });
+
+    var model = provider.languageModel("claude-sonnet-4-5-20250929");
+    var lm = model.asLanguageModel();
+
+    var ctx = StreamTestCtx{ .alloc = alloc };
+
+    const stream_result = ai.streamText(alloc, .{
+        .model = &lm,
+        .prompt = "Say hello in one word.",
+        .callbacks = ctx.callbacks(),
+    }) catch |err| {
+        std.debug.print("Anthropic streamText error: {}\n", .{err});
+        return err;
+    };
+
+    try testing.expect(ctx.completed);
+    try testing.expect(ctx.text_buf.items.len > 0);
+    try testing.expect(ctx.error_count == 0);
+    try testing.expect(stream_result.getText().len > 0);
 }
 
 // ============================================================================
@@ -270,6 +425,39 @@ test "live: Google error diagnostic on invalid key" {
     try testing.expect(diag.status_code != null);
 }
 
+test "live: Google streamText" {
+    const api_key = getEnv("GOOGLE_GENERATIVE_AI_API_KEY") orelse return;
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var http_client = provider_utils.createStdHttpClient(alloc);
+    var provider = google.createGoogleGenerativeAIWithSettings(alloc, .{
+        .api_key = api_key,
+        .http_client = http_client.asInterface(),
+    });
+
+    var model = provider.languageModel("gemini-2.0-flash");
+    var lm = model.asLanguageModel();
+
+    var ctx = StreamTestCtx{ .alloc = alloc };
+
+    const stream_result = ai.streamText(alloc, .{
+        .model = &lm,
+        .prompt = "Say hello in one word.",
+        .callbacks = ctx.callbacks(),
+    }) catch |err| {
+        std.debug.print("Google streamText error: {}\n", .{err});
+        return err;
+    };
+
+    try testing.expect(ctx.completed);
+    try testing.expect(ctx.text_buf.items.len > 0);
+    try testing.expect(ctx.error_count == 0);
+    try testing.expect(stream_result.getText().len > 0);
+}
+
 // ============================================================================
 // xAI (Grok)
 // ============================================================================
@@ -329,4 +517,37 @@ test "live: xAI error diagnostic on invalid key" {
     try testing.expect(diag.kind == .authentication or diag.kind == .invalid_request);
     try testing.expect(diag.message() != null);
     try testing.expect(diag.status_code != null);
+}
+
+test "live: xAI streamText" {
+    const api_key = getEnv("XAI_API_KEY") orelse return;
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var http_client = provider_utils.createStdHttpClient(alloc);
+    var provider = xai.createXaiWithSettings(alloc, .{
+        .api_key = api_key,
+        .http_client = http_client.asInterface(),
+    });
+
+    var model = provider.languageModel("grok-3-mini-fast");
+    var lm = model.asLanguageModel();
+
+    var ctx = StreamTestCtx{ .alloc = alloc };
+
+    const stream_result = ai.streamText(alloc, .{
+        .model = &lm,
+        .prompt = "Say hello in one word.",
+        .callbacks = ctx.callbacks(),
+    }) catch |err| {
+        std.debug.print("xAI streamText error: {}\n", .{err});
+        return err;
+    };
+
+    try testing.expect(ctx.completed);
+    try testing.expect(ctx.text_buf.items.len > 0);
+    try testing.expect(ctx.error_count == 0);
+    try testing.expect(stream_result.getText().len > 0);
 }


### PR DESCRIPTION
## Summary
- Add streaming (`streamText`) live tests for all 5 providers: OpenAI, Azure, Anthropic, Google, xAI
- Fix OpenAI streaming parser missing `ignore_unknown_fields = true` (same issue fixed for Anthropic in #76)
- Remove outdated "stub" comment — all providers have full streaming implementations
- Uses `ArenaAllocator` in streaming tests to handle provider-internal memory leaks during streaming

Fixes #77

## Test plan
- [x] All 15 live tests pass (10 existing + 5 new streamText tests)
- [x] All unit tests pass (no regressions)
- [x] Each streaming test verifies: stream completes, text received, no errors, result text accumulated

🤖 Generated with [Claude Code](https://claude.com/claude-code)