### PR TITLE
Update docs, .env.example, and add live test script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,15 @@
 # Copy this to .env and fill in your keys
 # Only set the providers you want to test
+# Tests skip automatically when a key is not set
 
 # OpenAI
 OPENAI_API_KEY=
+
+# Anthropic
+ANTHROPIC_API_KEY=
+
+# Google AI (Gemini)
+GOOGLE_GENERATIVE_AI_API_KEY=
 
 # xAI (Grok)
 XAI_API_KEY=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Zig AI SDK - A comprehensive AI SDK for Zig, ported from the Vercel AI SDK. Provides unified interfaces for 30+ AI providers including OpenAI, Anthropic, Google, Azure, AWS Bedrock, Mistral, and more. Supports text generation, streaming, tool calling, embeddings, image generation, speech synthesis, and transcription.
+Zig AI SDK - A comprehensive AI SDK for Zig, ported from the Vercel AI SDK. Provides unified interfaces for 14 AI provider packages including OpenAI, Anthropic, Google, Azure, xAI, and more. Supports text generation, streaming, tool calling, structured object generation, and embeddings.
 
 **Requirements**: Zig 0.15.0 or later
 
@@ -18,6 +18,24 @@ zig build run-example  # Run the example application
 ```
 
 There is no way to run individual test files - all tests are compiled and run together via `build.zig`.
+
+### Live Integration Tests
+
+Live tests require API keys in a `.env` file. Use the helper script:
+
+```bash
+cp .env.example .env       # Fill in your API keys
+./scripts/test-live.sh     # Loads .env and runs zig build test-live
+```
+
+Required env vars per provider:
+- `OPENAI_API_KEY`
+- `ANTHROPIC_API_KEY`
+- `GOOGLE_GENERATIVE_AI_API_KEY`
+- `XAI_API_KEY`
+- `AZURE_API_KEY`, `AZURE_RESOURCE_NAME`, `AZURE_DEPLOYMENT_NAME`
+
+Tests skip automatically when a provider's key is not set. The test file is at `tests/integration/live_provider_test.zig`.
 
 ## GitHub Workflow
 
@@ -66,7 +84,11 @@ packages/
 
 - `packages/provider/src/`: `JsonValue` (custom JSON type), error hierarchy, model interfaces
 - `packages/provider-utils/src/http/`: HTTP client abstraction and standard library implementation
-- `packages/ai/src/generate-text/`: Main text generation with streaming and tool support
+- `packages/ai/src/generate-text/`: Text generation with streaming and tool support
+- `packages/ai/src/generate-object/`: Structured object generation with JSON schema validation
+- `packages/ai/src/embed/`: Text embedding generation with similarity functions
+- `packages/ai/src/tool/`: Tool/function calling with agentic loop support
+- `packages/ai/src/middleware/`: Request/response middleware chain (rate limiting, etc.)
 
 ## Adding a New Provider
 

--- a/scripts/test-live.sh
+++ b/scripts/test-live.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Run live provider integration tests with API keys from .env
+#
+# Usage:
+#   ./scripts/test-live.sh          # Load .env and run all live tests
+#   ./scripts/test-live.sh path/to/.env  # Use a custom .env file
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+ENV_FILE="${1:-$PROJECT_ROOT/.env}"
+
+if [ ! -f "$ENV_FILE" ]; then
+    echo "Error: .env file not found at $ENV_FILE"
+    echo "Copy .env.example to .env and fill in your API keys:"
+    echo "  cp .env.example .env"
+    exit 1
+fi
+
+# Export variables from .env (skip comments and blank lines)
+set -a
+while IFS= read -r line || [ -n "$line" ]; do
+    # Skip comments and blank lines
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+    # Only export lines that look like KEY=VALUE
+    [[ "$line" =~ ^[A-Z_]+= ]] && eval "$line"
+done < "$ENV_FILE"
+set +a
+
+# Show which providers have keys configured
+echo "Provider status:"
+echo "  OpenAI:    $([ -n "${OPENAI_API_KEY:-}" ] && echo 'configured' || echo 'skipped (no OPENAI_API_KEY)')"
+echo "  Anthropic: $([ -n "${ANTHROPIC_API_KEY:-}" ] && echo 'configured' || echo 'skipped (no ANTHROPIC_API_KEY)')"
+echo "  Google:    $([ -n "${GOOGLE_GENERATIVE_AI_API_KEY:-}" ] && echo 'configured' || echo 'skipped (no GOOGLE_GENERATIVE_AI_API_KEY)')"
+echo "  xAI:       $([ -n "${XAI_API_KEY:-}" ] && echo 'configured' || echo 'skipped (no XAI_API_KEY)')"
+echo "  Azure:     $([ -n "${AZURE_API_KEY:-}" ] && echo 'configured' || echo 'skipped (no AZURE_API_KEY)')"
+echo ""
+
+cd "$PROJECT_ROOT"
+echo "Running live tests..."
+echo ""
+zig build test-live


### PR DESCRIPTION
## Summary
Fixes #79

- Fix provider count (30+ → 14) and remove all deleted providers from README lists
- Replace stale v0.2.0 changelog with **Roadmap** section: working features, known issues, planned work
- Fix placeholder installation URL (`your-org` → `evmts/ai-zig`)
- Add `defer result.deinit(allocator)` to Quick Start example
- Add Anthropic and Google keys to `.env.example`
- Create `scripts/test-live.sh` — loads `.env` and runs `zig build test-live`
- Add live test guidance and expanded core types to `CLAUDE.md`

## Test plan
- [x] `zig build test` passes (docs-only changes, no code impact)
- [x] `bash -n scripts/test-live.sh` syntax check passes
- [x] Review diffs for accuracy against actual package list

🤖 Generated with [Claude Code](https://claude.com/claude-code)