### PR TITLE
Replace trivial expect(true) in fireworks provider

### DIFF
--- a/packages/fireworks/src/fireworks-provider.zig
+++ b/packages/fireworks/src/fireworks-provider.zig
@@ -501,10 +501,10 @@ test "FireworksProvider deinit is idempotent" {
     const allocator = std.testing.allocator;
     var provider = createFireworks(allocator);
 
+    try std.testing.expectEqualStrings("fireworks", provider.getProvider());
+
     provider.deinit();
     provider.deinit(); // Should not crash
-
-    try std.testing.expect(true); // Test passes if we get here
 }
 
 test "FireworksProvider with very long model ID" {
@@ -543,9 +543,9 @@ test "fireworks providers have consistent values" {
 // ============================================================================
 
 test "getApiKeyFromEnv returns optional" {
-    // This test verifies the function can be called without error
     // The actual return value depends on environment variables
     const result = getApiKeyFromEnv();
-    _ = result; // May be null or a string, both are valid
-    try std.testing.expect(true);
+    if (result) |key| {
+        try std.testing.expect(key.len > 0);
+    }
 }


### PR DESCRIPTION
## Summary
- Replace `expect(true)` in deinit idempotency test with `expectEqualStrings` on provider name
- Replace `expect(true)` in `getApiKeyFromEnv` test with `key.len > 0` assertion when key is present

Fixes #83

## Test plan
- [x] `zig build test` — 806 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)