### PR TITLE
Update README test count to accurate 800+

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ ai-zig/
 
 ## Testing
 
-The SDK includes comprehensive unit tests (825+ passing):
+The SDK includes comprehensive unit tests (800+ passing, including ~33 compilation-verification tests via `refAllDecls`):
 
 ```bash
 zig build test


### PR DESCRIPTION
## Summary
- Update test count from stale "825+" to accurate "800+"
- Add qualifier noting ~33 are compilation-verification tests via `refAllDecls`

Fixes #85

## Test plan
- [x] Verified count: `zig build test` reports 806 total tests
- [x] 33 `refAllDecls` calls confirmed via grep

🤖 Generated with [Claude Code](https://claude.com/claude-code)