### PR TITLE
Fix silent catch return in streaming and test callbacks

### DIFF
--- a/packages/google/src/google-generative-ai-language-model.zig
+++ b/packages/google/src/google-generative-ai-language-model.zig
@@ -308,7 +308,10 @@ pub const GoogleGenerativeAILanguageModel = struct {
 
         fn processChunk(self: *StreamState, chunk: []const u8) void {
             // Append chunk to partial line buffer
-            self.partial_line.appendSlice(self.request_allocator, chunk) catch return;
+            self.partial_line.appendSlice(self.request_allocator, chunk) catch |err| {
+                self.callbacks.on_error(self.callbacks.ctx, err);
+                return;
+            };
 
             // Process complete lines
             while (std.mem.indexOf(u8, self.partial_line.items, "\n")) |newline_pos| {
@@ -340,7 +343,10 @@ pub const GoogleGenerativeAILanguageModel = struct {
                     self.request_allocator,
                     json_data,
                     .{ .ignore_unknown_fields = true },
-                ) catch return;
+                ) catch |err| {
+                    self.callbacks.on_error(self.callbacks.ctx, err);
+                    return;
+                };
                 defer parsed.deinit();
                 const response = parsed.value;
 

--- a/packages/openai/src/chat/openai-chat-language-model.zig
+++ b/packages/openai/src/chat/openai-chat-language-model.zig
@@ -704,7 +704,10 @@ const StreamState = struct {
                         });
 
                         // Emit tool call
-                        const args_copy = self.result_allocator.dupe(u8, tool_call.arguments.items) catch return;
+                        const args_copy = self.result_allocator.dupe(u8, tool_call.arguments.items) catch |err| {
+                            self.callbacks.on_error(self.callbacks.ctx, err);
+                            return;
+                        };
                         self.callbacks.on_part(self.callbacks.ctx, .{
                             .tool_call = .{
                                 .tool_call_id = tool_call.id,


### PR DESCRIPTION
## Summary

**Production code** — route errors to `callbacks.on_error` instead of silent return:
- Google streaming: `appendSlice` OOM and `parseFromSlice` errors now reported
- OpenAI streaming: tool call args `dupe` OOM now reported

**Test code** — add error tracking to EventSourceParser test contexts:
- Add `error_count: *usize` field to 7 test context structs
- Replace silent `catch return` with error count increment
- Assert `error_count == 0` after each test

Fixes #91

## Test plan
- [x] `zig build test` — 805 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)