### PR TITLE
Add behavioral tests to 5 thin OpenAI-compatible providers

### DIFF
--- a/packages/cerebras/src/cerebras-provider.zig
+++ b/packages/cerebras/src/cerebras-provider.zig
@@ -504,3 +504,171 @@ test "CerebrasProvider languageModel passes correct provider name" {
     // The model should be using "cerebras.chat" as provider
     try std.testing.expectEqualStrings("llama3.1-8b", model.getModelId());
 }
+
+// ============================================================================
+// Behavioral Tests (MockHttpClient)
+// ============================================================================
+
+test "Cerebras doGenerate succeeds via mock HTTP" {
+    const allocator = std.testing.allocator;
+    const lm = @import("provider").language_model;
+
+    var mock = provider_utils.MockHttpClient.init(allocator);
+    defer mock.deinit();
+
+    mock.setResponse(.{
+        .status_code = 200,
+        .body =
+            \\{"id":"chatcmpl-1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"Hello from Cerebras"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}
+        ,
+    });
+
+    var provider = createCerebrasWithSettings(allocator, .{
+        .api_key = "test-key",
+        .http_client = mock.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.languageModel("llama3.1-8b");
+
+    const msg = try lm.userTextMessage(allocator, "Hello");
+    defer allocator.free(msg.content.user);
+
+    var lm_model = model.asLanguageModel();
+    const CallbackCtx = struct { result: ?lm.LanguageModelV3.GenerateResult = null };
+    var cb_ctx = CallbackCtx{};
+
+    lm_model.doGenerate(
+        .{ .prompt = &.{msg} },
+        allocator,
+        struct {
+            fn onResult(ctx: ?*anyopaque, result: lm.LanguageModelV3.GenerateResult) void {
+                const c: *CallbackCtx = @ptrCast(@alignCast(ctx.?));
+                c.result = result;
+            }
+        }.onResult,
+        @as(?*anyopaque, @ptrCast(&cb_ctx)),
+    );
+
+    try std.testing.expect(cb_ctx.result != null);
+    switch (cb_ctx.result.?) {
+        .success => |success| {
+            try std.testing.expect(success.content.len > 0);
+            switch (success.content[0]) {
+                .text => |text| {
+                    try std.testing.expectEqualStrings("Hello from Cerebras", text.text);
+                    allocator.free(text.text);
+                },
+                else => try std.testing.expect(false),
+            }
+            allocator.free(success.content);
+            if (success.response) |resp| {
+                if (resp.metadata.id) |id| allocator.free(id);
+                if (resp.metadata.model_id) |mid| allocator.free(mid);
+            }
+        },
+        .failure => try std.testing.expect(false),
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), mock.requestCount());
+}
+
+test "Cerebras ErrorDiagnostic on HTTP 429 rate limit" {
+    const allocator = std.testing.allocator;
+    const ErrorDiagnostic = @import("provider").ErrorDiagnostic;
+    const lm = @import("provider").language_model;
+
+    var mock = provider_utils.MockHttpClient.init(allocator);
+    defer mock.deinit();
+
+    mock.setResponse(.{
+        .status_code = 429,
+        .body = "{\"error\":{\"message\":\"Rate limit exceeded\",\"type\":\"rate_limit_error\"}}",
+    });
+
+    var provider = createCerebrasWithSettings(allocator, .{
+        .api_key = "test-key",
+        .http_client = mock.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.languageModel("llama3.1-8b");
+
+    const msg = try lm.userTextMessage(allocator, "Hello");
+    defer allocator.free(msg.content.user);
+
+    var diag: ErrorDiagnostic = .{};
+    var lm_model = model.asLanguageModel();
+    const CallbackCtx = struct { result: ?lm.LanguageModelV3.GenerateResult = null };
+    var cb_ctx = CallbackCtx{};
+
+    lm_model.doGenerate(
+        .{ .prompt = &.{msg}, .error_diagnostic = &diag },
+        allocator,
+        struct {
+            fn onResult(ctx: ?*anyopaque, result: lm.LanguageModelV3.GenerateResult) void {
+                const c: *CallbackCtx = @ptrCast(@alignCast(ctx.?));
+                c.result = result;
+            }
+        }.onResult,
+        @as(?*anyopaque, @ptrCast(&cb_ctx)),
+    );
+
+    try std.testing.expect(cb_ctx.result != null);
+    switch (cb_ctx.result.?) {
+        .failure => {},
+        .success => try std.testing.expect(false),
+    }
+
+    try std.testing.expectEqual(@as(?u16, 429), diag.status_code);
+    try std.testing.expect(diag.kind == .rate_limit);
+    try std.testing.expect(diag.is_retryable);
+    try std.testing.expectEqualStrings("cerebras.chat", diag.provider.?);
+    try std.testing.expectEqualStrings("Rate limit exceeded", diag.message().?);
+}
+
+test "Cerebras ErrorDiagnostic on network error" {
+    const allocator = std.testing.allocator;
+    const ErrorDiagnostic = @import("provider").ErrorDiagnostic;
+    const lm = @import("provider").language_model;
+
+    var mock = provider_utils.MockHttpClient.init(allocator);
+    defer mock.deinit();
+
+    mock.setError(.{
+        .kind = .connection_failed,
+        .message = "Connection refused",
+    });
+
+    var provider = createCerebrasWithSettings(allocator, .{
+        .api_key = "test-key",
+        .http_client = mock.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.languageModel("llama3.1-8b");
+
+    const msg = try lm.userTextMessage(allocator, "Hello");
+    defer allocator.free(msg.content.user);
+
+    var diag: ErrorDiagnostic = .{};
+    var lm_model = model.asLanguageModel();
+    const CallbackCtx = struct { result: ?lm.LanguageModelV3.GenerateResult = null };
+    var cb_ctx = CallbackCtx{};
+
+    lm_model.doGenerate(
+        .{ .prompt = &.{msg}, .error_diagnostic = &diag },
+        allocator,
+        struct {
+            fn onResult(ctx: ?*anyopaque, result: lm.LanguageModelV3.GenerateResult) void {
+                const c: *CallbackCtx = @ptrCast(@alignCast(ctx.?));
+                c.result = result;
+            }
+        }.onResult,
+        @as(?*anyopaque, @ptrCast(&cb_ctx)),
+    );
+
+    try std.testing.expect(diag.kind == .network);
+    try std.testing.expectEqualStrings("Connection refused", diag.message().?);
+    try std.testing.expectEqualStrings("cerebras.chat", diag.provider.?);
+}

--- a/packages/deepinfra/src/deepinfra-provider.zig
+++ b/packages/deepinfra/src/deepinfra-provider.zig
@@ -466,3 +466,171 @@ test "DeepInfraProvider with empty model ID" {
     const model = provider.languageModel("");
     try std.testing.expectEqualStrings("", model.getModelId());
 }
+
+// ============================================================================
+// Behavioral Tests (MockHttpClient)
+// ============================================================================
+
+test "DeepInfra doGenerate succeeds via mock HTTP" {
+    const allocator = std.testing.allocator;
+    const lm = @import("provider").language_model;
+
+    var mock = provider_utils.MockHttpClient.init(allocator);
+    defer mock.deinit();
+
+    mock.setResponse(.{
+        .status_code = 200,
+        .body =
+            \\{"id":"chatcmpl-1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"Hello from DeepInfra"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}
+        ,
+    });
+
+    var provider = createDeepInfraWithSettings(allocator, .{
+        .api_key = "test-key",
+        .http_client = mock.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.languageModel("meta-llama/Meta-Llama-3-8B-Instruct");
+
+    const msg = try lm.userTextMessage(allocator, "Hello");
+    defer allocator.free(msg.content.user);
+
+    var lm_model = model.asLanguageModel();
+    const CallbackCtx = struct { result: ?lm.LanguageModelV3.GenerateResult = null };
+    var cb_ctx = CallbackCtx{};
+
+    lm_model.doGenerate(
+        .{ .prompt = &.{msg} },
+        allocator,
+        struct {
+            fn onResult(ctx: ?*anyopaque, result: lm.LanguageModelV3.GenerateResult) void {
+                const c: *CallbackCtx = @ptrCast(@alignCast(ctx.?));
+                c.result = result;
+            }
+        }.onResult,
+        @as(?*anyopaque, @ptrCast(&cb_ctx)),
+    );
+
+    try std.testing.expect(cb_ctx.result != null);
+    switch (cb_ctx.result.?) {
+        .success => |success| {
+            try std.testing.expect(success.content.len > 0);
+            switch (success.content[0]) {
+                .text => |text| {
+                    try std.testing.expectEqualStrings("Hello from DeepInfra", text.text);
+                    allocator.free(text.text);
+                },
+                else => try std.testing.expect(false),
+            }
+            allocator.free(success.content);
+            if (success.response) |resp| {
+                if (resp.metadata.id) |id| allocator.free(id);
+                if (resp.metadata.model_id) |mid| allocator.free(mid);
+            }
+        },
+        .failure => try std.testing.expect(false),
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), mock.requestCount());
+}
+
+test "DeepInfra ErrorDiagnostic on HTTP 429 rate limit" {
+    const allocator = std.testing.allocator;
+    const ErrorDiagnostic = @import("provider").ErrorDiagnostic;
+    const lm = @import("provider").language_model;
+
+    var mock = provider_utils.MockHttpClient.init(allocator);
+    defer mock.deinit();
+
+    mock.setResponse(.{
+        .status_code = 429,
+        .body = "{\"error\":{\"message\":\"Rate limit exceeded\",\"type\":\"rate_limit_error\"}}",
+    });
+
+    var provider = createDeepInfraWithSettings(allocator, .{
+        .api_key = "test-key",
+        .http_client = mock.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.languageModel("meta-llama/Meta-Llama-3-8B-Instruct");
+
+    const msg = try lm.userTextMessage(allocator, "Hello");
+    defer allocator.free(msg.content.user);
+
+    var diag: ErrorDiagnostic = .{};
+    var lm_model = model.asLanguageModel();
+    const CallbackCtx = struct { result: ?lm.LanguageModelV3.GenerateResult = null };
+    var cb_ctx = CallbackCtx{};
+
+    lm_model.doGenerate(
+        .{ .prompt = &.{msg}, .error_diagnostic = &diag },
+        allocator,
+        struct {
+            fn onResult(ctx: ?*anyopaque, result: lm.LanguageModelV3.GenerateResult) void {
+                const c: *CallbackCtx = @ptrCast(@alignCast(ctx.?));
+                c.result = result;
+            }
+        }.onResult,
+        @as(?*anyopaque, @ptrCast(&cb_ctx)),
+    );
+
+    try std.testing.expect(cb_ctx.result != null);
+    switch (cb_ctx.result.?) {
+        .failure => {},
+        .success => try std.testing.expect(false),
+    }
+
+    try std.testing.expectEqual(@as(?u16, 429), diag.status_code);
+    try std.testing.expect(diag.kind == .rate_limit);
+    try std.testing.expect(diag.is_retryable);
+    try std.testing.expectEqualStrings("deepinfra.chat", diag.provider.?);
+    try std.testing.expectEqualStrings("Rate limit exceeded", diag.message().?);
+}
+
+test "DeepInfra ErrorDiagnostic on network error" {
+    const allocator = std.testing.allocator;
+    const ErrorDiagnostic = @import("provider").ErrorDiagnostic;
+    const lm = @import("provider").language_model;
+
+    var mock = provider_utils.MockHttpClient.init(allocator);
+    defer mock.deinit();
+
+    mock.setError(.{
+        .kind = .connection_failed,
+        .message = "Connection refused",
+    });
+
+    var provider = createDeepInfraWithSettings(allocator, .{
+        .api_key = "test-key",
+        .http_client = mock.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.languageModel("meta-llama/Meta-Llama-3-8B-Instruct");
+
+    const msg = try lm.userTextMessage(allocator, "Hello");
+    defer allocator.free(msg.content.user);
+
+    var diag: ErrorDiagnostic = .{};
+    var lm_model = model.asLanguageModel();
+    const CallbackCtx = struct { result: ?lm.LanguageModelV3.GenerateResult = null };
+    var cb_ctx = CallbackCtx{};
+
+    lm_model.doGenerate(
+        .{ .prompt = &.{msg}, .error_diagnostic = &diag },
+        allocator,
+        struct {
+            fn onResult(ctx: ?*anyopaque, result: lm.LanguageModelV3.GenerateResult) void {
+                const c: *CallbackCtx = @ptrCast(@alignCast(ctx.?));
+                c.result = result;
+            }
+        }.onResult,
+        @as(?*anyopaque, @ptrCast(&cb_ctx)),
+    );
+
+    try std.testing.expect(diag.kind == .network);
+    try std.testing.expectEqualStrings("Connection refused", diag.message().?);
+    try std.testing.expectEqualStrings("deepinfra.chat", diag.provider.?);
+}

--- a/packages/huggingface/src/huggingface-provider.zig
+++ b/packages/huggingface/src/huggingface-provider.zig
@@ -444,3 +444,171 @@ test "huggingface provider returns consistent values" {
     try std.testing.expectEqualStrings("huggingface", provider1.getProvider());
     try std.testing.expectEqualStrings("huggingface", provider2.getProvider());
 }
+
+// ============================================================================
+// Behavioral Tests (MockHttpClient)
+// ============================================================================
+
+test "HuggingFace doGenerate succeeds via mock HTTP" {
+    const allocator = std.testing.allocator;
+    const lm = @import("provider").language_model;
+
+    var mock = provider_utils.MockHttpClient.init(allocator);
+    defer mock.deinit();
+
+    mock.setResponse(.{
+        .status_code = 200,
+        .body =
+            \\{"id":"chatcmpl-1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"Hello from HuggingFace"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}
+        ,
+    });
+
+    var provider = createHuggingFaceWithSettings(allocator, .{
+        .api_key = "test-key",
+        .http_client = mock.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.languageModel("mistralai/Mistral-7B-Instruct-v0.2");
+
+    const msg = try lm.userTextMessage(allocator, "Hello");
+    defer allocator.free(msg.content.user);
+
+    var lm_model = model.asLanguageModel();
+    const CallbackCtx = struct { result: ?lm.LanguageModelV3.GenerateResult = null };
+    var cb_ctx = CallbackCtx{};
+
+    lm_model.doGenerate(
+        .{ .prompt = &.{msg} },
+        allocator,
+        struct {
+            fn onResult(ctx: ?*anyopaque, result: lm.LanguageModelV3.GenerateResult) void {
+                const c: *CallbackCtx = @ptrCast(@alignCast(ctx.?));
+                c.result = result;
+            }
+        }.onResult,
+        @as(?*anyopaque, @ptrCast(&cb_ctx)),
+    );
+
+    try std.testing.expect(cb_ctx.result != null);
+    switch (cb_ctx.result.?) {
+        .success => |success| {
+            try std.testing.expect(success.content.len > 0);
+            switch (success.content[0]) {
+                .text => |text| {
+                    try std.testing.expectEqualStrings("Hello from HuggingFace", text.text);
+                    allocator.free(text.text);
+                },
+                else => try std.testing.expect(false),
+            }
+            allocator.free(success.content);
+            if (success.response) |resp| {
+                if (resp.metadata.id) |id| allocator.free(id);
+                if (resp.metadata.model_id) |mid| allocator.free(mid);
+            }
+        },
+        .failure => try std.testing.expect(false),
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), mock.requestCount());
+}
+
+test "HuggingFace ErrorDiagnostic on HTTP 429 rate limit" {
+    const allocator = std.testing.allocator;
+    const ErrorDiagnostic = @import("provider").ErrorDiagnostic;
+    const lm = @import("provider").language_model;
+
+    var mock = provider_utils.MockHttpClient.init(allocator);
+    defer mock.deinit();
+
+    mock.setResponse(.{
+        .status_code = 429,
+        .body = "{\"error\":{\"message\":\"Rate limit exceeded\",\"type\":\"rate_limit_error\"}}",
+    });
+
+    var provider = createHuggingFaceWithSettings(allocator, .{
+        .api_key = "test-key",
+        .http_client = mock.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.languageModel("mistralai/Mistral-7B-Instruct-v0.2");
+
+    const msg = try lm.userTextMessage(allocator, "Hello");
+    defer allocator.free(msg.content.user);
+
+    var diag: ErrorDiagnostic = .{};
+    var lm_model = model.asLanguageModel();
+    const CallbackCtx = struct { result: ?lm.LanguageModelV3.GenerateResult = null };
+    var cb_ctx = CallbackCtx{};
+
+    lm_model.doGenerate(
+        .{ .prompt = &.{msg}, .error_diagnostic = &diag },
+        allocator,
+        struct {
+            fn onResult(ctx: ?*anyopaque, result: lm.LanguageModelV3.GenerateResult) void {
+                const c: *CallbackCtx = @ptrCast(@alignCast(ctx.?));
+                c.result = result;
+            }
+        }.onResult,
+        @as(?*anyopaque, @ptrCast(&cb_ctx)),
+    );
+
+    try std.testing.expect(cb_ctx.result != null);
+    switch (cb_ctx.result.?) {
+        .failure => {},
+        .success => try std.testing.expect(false),
+    }
+
+    try std.testing.expectEqual(@as(?u16, 429), diag.status_code);
+    try std.testing.expect(diag.kind == .rate_limit);
+    try std.testing.expect(diag.is_retryable);
+    try std.testing.expectEqualStrings("huggingface.chat", diag.provider.?);
+    try std.testing.expectEqualStrings("Rate limit exceeded", diag.message().?);
+}
+
+test "HuggingFace ErrorDiagnostic on network error" {
+    const allocator = std.testing.allocator;
+    const ErrorDiagnostic = @import("provider").ErrorDiagnostic;
+    const lm = @import("provider").language_model;
+
+    var mock = provider_utils.MockHttpClient.init(allocator);
+    defer mock.deinit();
+
+    mock.setError(.{
+        .kind = .connection_failed,
+        .message = "Connection refused",
+    });
+
+    var provider = createHuggingFaceWithSettings(allocator, .{
+        .api_key = "test-key",
+        .http_client = mock.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.languageModel("mistralai/Mistral-7B-Instruct-v0.2");
+
+    const msg = try lm.userTextMessage(allocator, "Hello");
+    defer allocator.free(msg.content.user);
+
+    var diag: ErrorDiagnostic = .{};
+    var lm_model = model.asLanguageModel();
+    const CallbackCtx = struct { result: ?lm.LanguageModelV3.GenerateResult = null };
+    var cb_ctx = CallbackCtx{};
+
+    lm_model.doGenerate(
+        .{ .prompt = &.{msg}, .error_diagnostic = &diag },
+        allocator,
+        struct {
+            fn onResult(ctx: ?*anyopaque, result: lm.LanguageModelV3.GenerateResult) void {
+                const c: *CallbackCtx = @ptrCast(@alignCast(ctx.?));
+                c.result = result;
+            }
+        }.onResult,
+        @as(?*anyopaque, @ptrCast(&cb_ctx)),
+    );
+
+    try std.testing.expect(diag.kind == .network);
+    try std.testing.expectEqualStrings("Connection refused", diag.message().?);
+    try std.testing.expectEqualStrings("huggingface.chat", diag.provider.?);
+}

--- a/packages/perplexity/src/perplexity-provider.zig
+++ b/packages/perplexity/src/perplexity-provider.zig
@@ -464,3 +464,171 @@ test "PerplexityProvider edge case: special characters in model ID" {
         try std.testing.expectEqualStrings(model_id, model.getModelId());
     }
 }
+
+// ============================================================================
+// Behavioral Tests (MockHttpClient)
+// ============================================================================
+
+test "Perplexity doGenerate succeeds via mock HTTP" {
+    const allocator = std.testing.allocator;
+    const lm = @import("provider").language_model;
+
+    var mock = provider_utils.MockHttpClient.init(allocator);
+    defer mock.deinit();
+
+    mock.setResponse(.{
+        .status_code = 200,
+        .body =
+            \\{"id":"chatcmpl-1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"Hello from Perplexity"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}
+        ,
+    });
+
+    var provider = createPerplexityWithSettings(allocator, .{
+        .api_key = "test-key",
+        .http_client = mock.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.languageModel("llama-3.1-sonar-small-128k-online");
+
+    const msg = try lm.userTextMessage(allocator, "Hello");
+    defer allocator.free(msg.content.user);
+
+    var lm_model = model.asLanguageModel();
+    const CallbackCtx = struct { result: ?lm.LanguageModelV3.GenerateResult = null };
+    var cb_ctx = CallbackCtx{};
+
+    lm_model.doGenerate(
+        .{ .prompt = &.{msg} },
+        allocator,
+        struct {
+            fn onResult(ctx: ?*anyopaque, result: lm.LanguageModelV3.GenerateResult) void {
+                const c: *CallbackCtx = @ptrCast(@alignCast(ctx.?));
+                c.result = result;
+            }
+        }.onResult,
+        @as(?*anyopaque, @ptrCast(&cb_ctx)),
+    );
+
+    try std.testing.expect(cb_ctx.result != null);
+    switch (cb_ctx.result.?) {
+        .success => |success| {
+            try std.testing.expect(success.content.len > 0);
+            switch (success.content[0]) {
+                .text => |text| {
+                    try std.testing.expectEqualStrings("Hello from Perplexity", text.text);
+                    allocator.free(text.text);
+                },
+                else => try std.testing.expect(false),
+            }
+            allocator.free(success.content);
+            if (success.response) |resp| {
+                if (resp.metadata.id) |id| allocator.free(id);
+                if (resp.metadata.model_id) |mid| allocator.free(mid);
+            }
+        },
+        .failure => try std.testing.expect(false),
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), mock.requestCount());
+}
+
+test "Perplexity ErrorDiagnostic on HTTP 429 rate limit" {
+    const allocator = std.testing.allocator;
+    const ErrorDiagnostic = @import("provider").ErrorDiagnostic;
+    const lm = @import("provider").language_model;
+
+    var mock = provider_utils.MockHttpClient.init(allocator);
+    defer mock.deinit();
+
+    mock.setResponse(.{
+        .status_code = 429,
+        .body = "{\"error\":{\"message\":\"Rate limit exceeded\",\"type\":\"rate_limit_error\"}}",
+    });
+
+    var provider = createPerplexityWithSettings(allocator, .{
+        .api_key = "test-key",
+        .http_client = mock.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.languageModel("llama-3.1-sonar-small-128k-online");
+
+    const msg = try lm.userTextMessage(allocator, "Hello");
+    defer allocator.free(msg.content.user);
+
+    var diag: ErrorDiagnostic = .{};
+    var lm_model = model.asLanguageModel();
+    const CallbackCtx = struct { result: ?lm.LanguageModelV3.GenerateResult = null };
+    var cb_ctx = CallbackCtx{};
+
+    lm_model.doGenerate(
+        .{ .prompt = &.{msg}, .error_diagnostic = &diag },
+        allocator,
+        struct {
+            fn onResult(ctx: ?*anyopaque, result: lm.LanguageModelV3.GenerateResult) void {
+                const c: *CallbackCtx = @ptrCast(@alignCast(ctx.?));
+                c.result = result;
+            }
+        }.onResult,
+        @as(?*anyopaque, @ptrCast(&cb_ctx)),
+    );
+
+    try std.testing.expect(cb_ctx.result != null);
+    switch (cb_ctx.result.?) {
+        .failure => {},
+        .success => try std.testing.expect(false),
+    }
+
+    try std.testing.expectEqual(@as(?u16, 429), diag.status_code);
+    try std.testing.expect(diag.kind == .rate_limit);
+    try std.testing.expect(diag.is_retryable);
+    try std.testing.expectEqualStrings("perplexity.chat", diag.provider.?);
+    try std.testing.expectEqualStrings("Rate limit exceeded", diag.message().?);
+}
+
+test "Perplexity ErrorDiagnostic on network error" {
+    const allocator = std.testing.allocator;
+    const ErrorDiagnostic = @import("provider").ErrorDiagnostic;
+    const lm = @import("provider").language_model;
+
+    var mock = provider_utils.MockHttpClient.init(allocator);
+    defer mock.deinit();
+
+    mock.setError(.{
+        .kind = .connection_failed,
+        .message = "Connection refused",
+    });
+
+    var provider = createPerplexityWithSettings(allocator, .{
+        .api_key = "test-key",
+        .http_client = mock.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.languageModel("llama-3.1-sonar-small-128k-online");
+
+    const msg = try lm.userTextMessage(allocator, "Hello");
+    defer allocator.free(msg.content.user);
+
+    var diag: ErrorDiagnostic = .{};
+    var lm_model = model.asLanguageModel();
+    const CallbackCtx = struct { result: ?lm.LanguageModelV3.GenerateResult = null };
+    var cb_ctx = CallbackCtx{};
+
+    lm_model.doGenerate(
+        .{ .prompt = &.{msg}, .error_diagnostic = &diag },
+        allocator,
+        struct {
+            fn onResult(ctx: ?*anyopaque, result: lm.LanguageModelV3.GenerateResult) void {
+                const c: *CallbackCtx = @ptrCast(@alignCast(ctx.?));
+                c.result = result;
+            }
+        }.onResult,
+        @as(?*anyopaque, @ptrCast(&cb_ctx)),
+    );
+
+    try std.testing.expect(diag.kind == .network);
+    try std.testing.expectEqualStrings("Connection refused", diag.message().?);
+    try std.testing.expectEqualStrings("perplexity.chat", diag.provider.?);
+}

--- a/packages/togetherai/src/togetherai-provider.zig
+++ b/packages/togetherai/src/togetherai-provider.zig
@@ -540,3 +540,171 @@ test "TogetherAIProvider common model names" {
     try std.testing.expectEqualStrings("mistralai/Mixtral-8x7B-Instruct-v0.1", mixtral.getModelId());
     try std.testing.expectEqualStrings("Qwen/Qwen2.5-7B-Instruct-Turbo", qwen.getModelId());
 }
+
+// ============================================================================
+// Behavioral Tests (MockHttpClient)
+// ============================================================================
+
+test "TogetherAI doGenerate succeeds via mock HTTP" {
+    const allocator = std.testing.allocator;
+    const lm = @import("provider").language_model;
+
+    var mock = provider_utils.MockHttpClient.init(allocator);
+    defer mock.deinit();
+
+    mock.setResponse(.{
+        .status_code = 200,
+        .body =
+            \\{"id":"chatcmpl-1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"Hello from TogetherAI"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}
+        ,
+    });
+
+    var provider = createTogetherAIWithSettings(allocator, .{
+        .api_key = "test-key",
+        .http_client = mock.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.languageModel("meta-llama/Llama-3-8b-chat-hf");
+
+    const msg = try lm.userTextMessage(allocator, "Hello");
+    defer allocator.free(msg.content.user);
+
+    var lm_model = model.asLanguageModel();
+    const CallbackCtx = struct { result: ?lm.LanguageModelV3.GenerateResult = null };
+    var cb_ctx = CallbackCtx{};
+
+    lm_model.doGenerate(
+        .{ .prompt = &.{msg} },
+        allocator,
+        struct {
+            fn onResult(ctx: ?*anyopaque, result: lm.LanguageModelV3.GenerateResult) void {
+                const c: *CallbackCtx = @ptrCast(@alignCast(ctx.?));
+                c.result = result;
+            }
+        }.onResult,
+        @as(?*anyopaque, @ptrCast(&cb_ctx)),
+    );
+
+    try std.testing.expect(cb_ctx.result != null);
+    switch (cb_ctx.result.?) {
+        .success => |success| {
+            try std.testing.expect(success.content.len > 0);
+            switch (success.content[0]) {
+                .text => |text| {
+                    try std.testing.expectEqualStrings("Hello from TogetherAI", text.text);
+                    allocator.free(text.text);
+                },
+                else => try std.testing.expect(false),
+            }
+            allocator.free(success.content);
+            if (success.response) |resp| {
+                if (resp.metadata.id) |id| allocator.free(id);
+                if (resp.metadata.model_id) |mid| allocator.free(mid);
+            }
+        },
+        .failure => try std.testing.expect(false),
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), mock.requestCount());
+}
+
+test "TogetherAI ErrorDiagnostic on HTTP 429 rate limit" {
+    const allocator = std.testing.allocator;
+    const ErrorDiagnostic = @import("provider").ErrorDiagnostic;
+    const lm = @import("provider").language_model;
+
+    var mock = provider_utils.MockHttpClient.init(allocator);
+    defer mock.deinit();
+
+    mock.setResponse(.{
+        .status_code = 429,
+        .body = "{\"error\":{\"message\":\"Rate limit exceeded\",\"type\":\"rate_limit_error\"}}",
+    });
+
+    var provider = createTogetherAIWithSettings(allocator, .{
+        .api_key = "test-key",
+        .http_client = mock.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.languageModel("meta-llama/Llama-3-8b-chat-hf");
+
+    const msg = try lm.userTextMessage(allocator, "Hello");
+    defer allocator.free(msg.content.user);
+
+    var diag: ErrorDiagnostic = .{};
+    var lm_model = model.asLanguageModel();
+    const CallbackCtx = struct { result: ?lm.LanguageModelV3.GenerateResult = null };
+    var cb_ctx = CallbackCtx{};
+
+    lm_model.doGenerate(
+        .{ .prompt = &.{msg}, .error_diagnostic = &diag },
+        allocator,
+        struct {
+            fn onResult(ctx: ?*anyopaque, result: lm.LanguageModelV3.GenerateResult) void {
+                const c: *CallbackCtx = @ptrCast(@alignCast(ctx.?));
+                c.result = result;
+            }
+        }.onResult,
+        @as(?*anyopaque, @ptrCast(&cb_ctx)),
+    );
+
+    try std.testing.expect(cb_ctx.result != null);
+    switch (cb_ctx.result.?) {
+        .failure => {},
+        .success => try std.testing.expect(false),
+    }
+
+    try std.testing.expectEqual(@as(?u16, 429), diag.status_code);
+    try std.testing.expect(diag.kind == .rate_limit);
+    try std.testing.expect(diag.is_retryable);
+    try std.testing.expectEqualStrings("togetherai.chat", diag.provider.?);
+    try std.testing.expectEqualStrings("Rate limit exceeded", diag.message().?);
+}
+
+test "TogetherAI ErrorDiagnostic on network error" {
+    const allocator = std.testing.allocator;
+    const ErrorDiagnostic = @import("provider").ErrorDiagnostic;
+    const lm = @import("provider").language_model;
+
+    var mock = provider_utils.MockHttpClient.init(allocator);
+    defer mock.deinit();
+
+    mock.setError(.{
+        .kind = .connection_failed,
+        .message = "Connection refused",
+    });
+
+    var provider = createTogetherAIWithSettings(allocator, .{
+        .api_key = "test-key",
+        .http_client = mock.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.languageModel("meta-llama/Llama-3-8b-chat-hf");
+
+    const msg = try lm.userTextMessage(allocator, "Hello");
+    defer allocator.free(msg.content.user);
+
+    var diag: ErrorDiagnostic = .{};
+    var lm_model = model.asLanguageModel();
+    const CallbackCtx = struct { result: ?lm.LanguageModelV3.GenerateResult = null };
+    var cb_ctx = CallbackCtx{};
+
+    lm_model.doGenerate(
+        .{ .prompt = &.{msg}, .error_diagnostic = &diag },
+        allocator,
+        struct {
+            fn onResult(ctx: ?*anyopaque, result: lm.LanguageModelV3.GenerateResult) void {
+                const c: *CallbackCtx = @ptrCast(@alignCast(ctx.?));
+                c.result = result;
+            }
+        }.onResult,
+        @as(?*anyopaque, @ptrCast(&cb_ctx)),
+    );
+
+    try std.testing.expect(diag.kind == .network);
+    try std.testing.expectEqualStrings("Connection refused", diag.message().?);
+    try std.testing.expectEqualStrings("togetherai.chat", diag.provider.?);
+}


### PR DESCRIPTION
## Summary
Add MockHttpClient-based behavioral tests to providers that previously only had init/config tests:

| Provider | Tests Added |
|----------|------------|
| Perplexity | doGenerate success, HTTP 429, network error |
| TogetherAI | doGenerate success, HTTP 429, network error |
| DeepInfra | doGenerate success, HTTP 429, network error |
| Cerebras | doGenerate success, HTTP 429, network error |
| HuggingFace | doGenerate success, HTTP 429, network error |

Pattern follows Azure/xAI test template: inject canned JSON via MockHttpClient, call doGenerate through vtable, assert parsed result and ErrorDiagnostic.

Fixes #93

## Test plan
- [x] `zig build test` — 820 tests pass (was 805, +15 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)