### PR TITLE
Complete API response structs for OpenAI, Anthropic, Google

### DIFF
--- a/packages/anthropic/src/anthropic-messages-api.zig
+++ b/packages/anthropic/src/anthropic-messages-api.zig
@@ -138,6 +138,13 @@ pub const AnthropicMessagesResponse = struct {
         output_tokens: u64,
         cache_creation_input_tokens: ?u64 = null,
         cache_read_input_tokens: ?u64 = null,
+        cache_creation: ?CacheCreation = null,
+        service_tier: ?[]const u8 = null,
+    };
+
+    pub const CacheCreation = struct {
+        ephemeral_5m_input_tokens: ?u64 = null,
+        ephemeral_1h_input_tokens: ?u64 = null,
     };
 
     pub const Container = struct {
@@ -467,6 +474,7 @@ pub const AnthropicMessagesChunk = struct {
 
     pub const UsageDelta = struct {
         output_tokens: u64,
+        input_tokens: ?u64 = null,
     };
 
     pub const ErrorChunk = struct {

--- a/packages/google/src/google-generative-ai-response.zig
+++ b/packages/google/src/google-generative-ai-response.zig
@@ -14,6 +14,9 @@ pub const GoogleGenerateContentResponse = struct {
         citationMetadata: ?CitationMetadata = null,
         index: ?u32 = null,
         groundingMetadata: ?GroundingMetadata = null,
+        avgLogprobs: ?f64 = null,
+        logprobsResult: ?LogprobsResult = null,
+        tokenCount: ?u32 = null,
     };
 
     pub const Content = struct {
@@ -99,6 +102,7 @@ pub const GoogleGenerateContentResponse = struct {
     pub const RetrievedContext = struct {
         uri: ?[]const u8 = null,
         title: ?[]const u8 = null,
+        text: ?[]const u8 = null,
     };
 
     pub const GroundingSupport = struct {
@@ -118,12 +122,28 @@ pub const GoogleGenerateContentResponse = struct {
         googleSearchDynamicRetrievalScore: ?f64 = null,
     };
 
+    pub const LogprobsResult = struct {
+        topCandidates: ?[]TopCandidates = null,
+        chosenCandidates: ?[]LogprobsCandidate = null,
+    };
+
+    pub const TopCandidates = struct {
+        candidates: ?[]LogprobsCandidate = null,
+    };
+
+    pub const LogprobsCandidate = struct {
+        token: ?[]const u8 = null,
+        tokenId: ?u32 = null,
+        logProbability: ?f64 = null,
+    };
+
     pub const UsageMetadata = struct {
         promptTokenCount: ?u32 = null,
         candidatesTokenCount: ?u32 = null,
         totalTokenCount: ?u32 = null,
         cachedContentTokenCount: ?u32 = null,
         thoughtsTokenCount: ?u32 = null,
+        toolUsePromptTokenCount: ?u32 = null,
     };
 
     pub const PromptFeedback = struct {

--- a/packages/openai/src/chat/openai-chat-api.zig
+++ b/packages/openai/src/chat/openai-chat-api.zig
@@ -10,6 +10,7 @@ pub const OpenAIChatResponse = struct {
     choices: []const Choice,
     usage: ?Usage = null,
     system_fingerprint: ?[]const u8 = null,
+    service_tier: ?[]const u8 = null,
 
     pub const Choice = struct {
         index: u32,
@@ -21,6 +22,7 @@ pub const OpenAIChatResponse = struct {
     pub const Message = struct {
         role: []const u8,
         content: ?[]const u8 = null,
+        refusal: ?[]const u8 = null,
         tool_calls: ?[]const ToolCall = null,
         annotations: ?[]const Annotation = null,
     };
@@ -90,6 +92,7 @@ pub const OpenAIChatChunk = struct {
     choices: []const ChunkChoice = &[_]ChunkChoice{},
     usage: ?OpenAIChatResponse.Usage = null,
     system_fingerprint: ?[]const u8 = null,
+    service_tier: ?[]const u8 = null,
 
     /// Error field for error chunks
     @"error": ?ChunkError = null,
@@ -110,6 +113,7 @@ pub const OpenAIChatChunk = struct {
     pub const Delta = struct {
         role: ?[]const u8 = null,
         content: ?[]const u8 = null,
+        refusal: ?[]const u8 = null,
         tool_calls: ?[]const DeltaToolCall = null,
         annotations: ?[]const OpenAIChatResponse.Annotation = null,
     };


### PR DESCRIPTION
## Summary
- **OpenAI**: Add `service_tier` to response and chunk, `refusal` to message and delta
- **Anthropic**: Add `cache_creation` sub-object (ephemeral TTL token counts) and `service_tier` to Usage, `input_tokens` to UsageDelta
- **Google**: Add `avgLogprobs`, `logprobsResult`, `tokenCount` to Candidate; `LogprobsResult`/`TopCandidates`/`LogprobsCandidate` types; `text` to `RetrievedContext`; `toolUsePromptTokenCount` to UsageMetadata

All fields are optional with null defaults, so existing parsing continues to work. Fields identified from real API response fixtures and official documentation.

Fixes #97

## Test plan
- [x] `zig build test` — all tests pass (no regressions)
- [x] All new fields are optional (`?T = null`) so existing JSON parsing with `ignore_unknown_fields = true` is unaffected
- [x] Verified against real API fixtures in `packages/*/src/__fixtures__/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)