### PR TITLE
Update README and CHANGELOG for audit fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-02-15
+
+### Fixed
+
+- **Streaming memory leak**: Added arena-per-stream architecture to OpenAI, Anthropic, OpenAI-compatible providers; fixed missing `defer arena.deinit()` in Google provider (#95, #96)
+- **Silent `catch return`**: Routed errors to callbacks instead of silently returning in test and production streaming code (#91, #92)
+- **Trivial test assertions**: Replaced `expect(true)` with meaningful assertions in Fireworks provider (#83, #84)
+- **`@panic("OOM")` in tests**: Replaced panics with error flags in test helpers (#87, #88)
+
+### Added
+
+- **Behavioral tests for thin providers**: Added doGenerate, HTTP error, and transport error tests for Perplexity, TogetherAI, DeepInfra, Cerebras, HuggingFace (#93, #94)
+- **API response struct fields**: Added `service_tier`, `refusal` (OpenAI); `cache_creation`, `service_tier` (Anthropic); `avgLogprobs`, `logprobsResult`, `tokenCount` (Google) (#97, #98)
+
+### Removed
+
+- **Dead code**: Removed unused `JsonEventStreamParser(T)` and `SimpleJsonEventStreamParser` (#89, #90)
+
+### Changed
+
+- 820+ unit tests passing across all packages (#84-#98)
+
 ## [0.2.0] - 2026-02-14
 
 ### Added
@@ -37,7 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Consolidated to 14 working provider packages: OpenAI, Anthropic, Google, Google Vertex, Azure, xAI, Perplexity, Together AI, Fireworks, Cerebras, DeepInfra, HuggingFace, OpenAI Compatible, and provider-utils
 - Updated documentation: README, CLAUDE.md, `.env.example` (#80)
-- 825+ unit tests passing across all packages
+- 825 unit tests passing across all packages
 
 ## [0.1.0] - 2024-12-19
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ ai-zig/
 
 ## Testing
 
-The SDK includes comprehensive unit tests (800+ passing, including ~33 compilation-verification tests via `refAllDecls`):
+The SDK includes comprehensive unit tests (820+ passing, including ~33 compilation-verification tests via `refAllDecls`):
 
 ```bash
 zig build test
@@ -296,12 +296,11 @@ try std.testing.expectEqualStrings("POST", req.method.toString());
 - `generateImage`, `generateSpeech`, `transcribe` - API surface exists, no provider implementations yet
 
 ### Known Issues
-- **Streaming memory**: Provider `doStream` implementations allocate internally without proper cleanup; streaming tests use `ArenaAllocator` as a workaround
-- **API response coverage**: Some provider response structs don't cover all fields returned by live APIs; `ignore_unknown_fields` is used as a temporary workaround until structs are updated to match full API schemas
+- **Live test coverage**: Live integration tests only cover basic `generateText`/`streamText` and error diagnostics; tool calling, `generateObject`, `streamObject`, and embeddings are not yet tested against real APIs
+- **`ignore_unknown_fields`**: Response structs cover common fields but not every API response field; `ignore_unknown_fields = true` is used for forward compatibility
 
 ### Planned
-- Complete API response struct coverage for all providers
-- Fix streaming memory management
+- Live integration tests for tool calling, structured output, and embeddings
 - Re-enable removed providers (Mistral, Groq, DeepSeek, Cohere, Bedrock, etc.)
 - Image generation providers (Fal, FLUX, DALL-E)
 - Speech/audio providers (ElevenLabs, Deepgram, etc.)


### PR DESCRIPTION
## Summary
- Update test count from 800+ to 820+
- Remove resolved known issues (streaming memory leak fixed in #96, API response coverage in #98)
- Add CHANGELOG 0.2.1 entry for all audit PRs (#84-#98)
- Update planned items to reflect current state

Fixes #99

## Test plan
- [x] `zig build test` passes (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)