### PR TITLE
Eliminate false-positive tests in live and unit suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- 820+ unit tests passing across all packages (#84-#98)
+- 830+ unit tests passing across all packages (#84-#98)
 
 ## [0.2.0] - 2026-02-14
 
@@ -59,7 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Consolidated to 14 working provider packages: OpenAI, Anthropic, Google, Google Vertex, Azure, xAI, Perplexity, Together AI, Fireworks, Cerebras, DeepInfra, HuggingFace, OpenAI Compatible, and provider-utils
 - Updated documentation: README, CLAUDE.md, `.env.example` (#80)
-- 825 unit tests passing across all packages
+- 830+ unit tests passing across all packages
 
 ## [0.1.0] - 2024-12-19
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ ai-zig/
 
 ## Testing
 
-The SDK includes comprehensive unit tests (820+ passing, including ~33 compilation-verification tests via `refAllDecls`):
+The SDK includes comprehensive unit tests (830+ passing, including ~33 compilation-verification tests via `refAllDecls`):
 
 ```bash
 zig build test

--- a/packages/azure/src/azure-openai-provider.zig
+++ b/packages/azure/src/azure-openai-provider.zig
@@ -685,18 +685,6 @@ test "AzureOpenAIProvider allocator usage" {
     try std.testing.expectEqual(allocator, provider.allocator);
 }
 
-test "AzureOpenAIProvider deinit safety" {
-    const allocator = std.testing.allocator;
-
-    var provider = createAzureWithSettings(allocator, .{
-        .base_url = "https://myresource.openai.azure.com/openai",
-    });
-
-    // Call deinit multiple times should be safe
-    provider.deinit();
-    provider.deinit();
-}
-
 test "AzureOpenAIProvider different API versions" {
     const allocator = std.testing.allocator;
 

--- a/packages/cerebras/src/cerebras-provider.zig
+++ b/packages/cerebras/src/cerebras-provider.zig
@@ -483,17 +483,6 @@ test "CerebrasProvider model with special characters" {
     try std.testing.expectEqualStrings(special_model_id, model.getModelId());
 }
 
-test "CerebrasProvider deinit multiple times" {
-    const allocator = std.testing.allocator;
-    var provider = createCerebras(allocator);
-
-    // First deinit
-    provider.deinit();
-
-    // Second deinit should not crash
-    provider.deinit();
-}
-
 test "CerebrasProvider languageModel passes correct provider name" {
     const allocator = std.testing.allocator;
     var provider = createCerebras(allocator);

--- a/packages/deepinfra/src/deepinfra-provider.zig
+++ b/packages/deepinfra/src/deepinfra-provider.zig
@@ -448,15 +448,6 @@ test "provider can create multiple models" {
     try std.testing.expectEqualStrings("embed-2", embed2.getModelId());
 }
 
-test "DeepInfraProvider deinit is idempotent" {
-    const allocator = std.testing.allocator;
-    var provider = createDeepInfra(allocator);
-
-    // Multiple calls to deinit should not cause issues
-    provider.deinit();
-    provider.deinit();
-}
-
 test "DeepInfraProvider with empty model ID" {
     const allocator = std.testing.allocator;
     var provider = createDeepInfra(allocator);

--- a/packages/huggingface/src/huggingface-provider.zig
+++ b/packages/huggingface/src/huggingface-provider.zig
@@ -425,15 +425,6 @@ test "HuggingFaceProvider init preserves allocator" {
     try std.testing.expect(provider.allocator.ptr == allocator.ptr);
 }
 
-test "HuggingFaceProvider deinit is safe to call" {
-    const allocator = std.testing.allocator;
-    var provider = createHuggingFace(allocator);
-
-    // Should not crash or leak
-    provider.deinit();
-    provider.deinit(); // Safe to call multiple times
-}
-
 test "huggingface provider returns consistent values" {
     var provider1 = createHuggingFace(std.testing.allocator);
     defer provider1.deinit();

--- a/packages/perplexity/src/perplexity-provider.zig
+++ b/packages/perplexity/src/perplexity-provider.zig
@@ -379,17 +379,6 @@ test "PerplexityProvider init with null settings uses defaults" {
     try std.testing.expectEqualStrings("https://api.perplexity.ai", provider.base_url);
 }
 
-test "PerplexityProvider deinit is safe to call" {
-    const allocator = std.testing.allocator;
-    var provider = createPerplexity(allocator);
-
-    // Should not crash or leak
-    provider.deinit();
-
-    // Safe to call multiple times
-    provider.deinit();
-}
-
 test "PerplexityProvider getProvider is const" {
     const allocator = std.testing.allocator;
     var provider = createPerplexity(allocator);

--- a/packages/togetherai/src/togetherai-provider.zig
+++ b/packages/togetherai/src/togetherai-provider.zig
@@ -402,16 +402,6 @@ test "createTogetherAI and createTogetherAIWithSettings produce equivalent resul
     try std.testing.expectEqualStrings(provider1.base_url, provider2.base_url);
 }
 
-test "TogetherAIProvider deinit is safe to call" {
-    const allocator = std.testing.allocator;
-
-    var provider = createTogetherAI(allocator);
-    provider.deinit();
-
-    // Calling deinit multiple times should be safe
-    provider.deinit();
-}
-
 test "TogetherAIProvider model IDs with special characters" {
     const allocator = std.testing.allocator;
 
@@ -474,34 +464,6 @@ test "TogetherAIProvider base_url with trailing slash" {
     defer provider.deinit();
 
     try std.testing.expectEqualStrings("https://api.example.com/v1/", provider.base_url);
-}
-
-test "TogetherAIProvider language model inherits base_url from provider" {
-    const allocator = std.testing.allocator;
-    const custom_url = "https://custom.together.ai/api";
-
-    var provider = createTogetherAIWithSettings(allocator, .{
-        .base_url = custom_url,
-    });
-    defer provider.deinit();
-
-    const model = provider.languageModel("test-model");
-    // The model should use the custom base_url from the provider
-    _ = model;
-}
-
-test "TogetherAIProvider embedding model inherits base_url from provider" {
-    const allocator = std.testing.allocator;
-    const custom_url = "https://custom.together.ai/api";
-
-    var provider = createTogetherAIWithSettings(allocator, .{
-        .base_url = custom_url,
-    });
-    defer provider.deinit();
-
-    const model = provider.embeddingModel("test-embed-model");
-    // The model should use the custom base_url from the provider
-    _ = model;
 }
 
 test "TogetherAIProvider vtable pointer cast safety" {

--- a/tests/integration/live_provider_test.zig
+++ b/tests/integration/live_provider_test.zig
@@ -81,7 +81,7 @@ const StreamTestCtx = struct {
 // ============================================================================
 
 test "live: OpenAI generateText" {
-    const api_key = getEnv("OPENAI_API_KEY") orelse return;
+    const api_key = getEnv("OPENAI_API_KEY") orelse return error.SkipZigTest;
     const allocator = testing.allocator;
 
     var http_client = provider_utils.createStdHttpClient(allocator);
@@ -109,7 +109,7 @@ test "live: OpenAI generateText" {
 
 test "live: OpenAI error diagnostic on invalid key" {
     const allocator = testing.allocator;
-    _ = getEnv("OPENAI_API_KEY") orelse return;
+    _ = getEnv("OPENAI_API_KEY") orelse return error.SkipZigTest;
 
     var http_client = provider_utils.createStdHttpClient(allocator);
     defer http_client.deinit();
@@ -137,7 +137,7 @@ test "live: OpenAI error diagnostic on invalid key" {
 }
 
 test "live: OpenAI streamText" {
-    const api_key = getEnv("OPENAI_API_KEY") orelse return;
+    const api_key = getEnv("OPENAI_API_KEY") orelse return error.SkipZigTest;
     const alloc = testing.allocator;
 
     var http_client = provider_utils.createStdHttpClient(alloc);
@@ -176,9 +176,9 @@ test "live: OpenAI streamText" {
 // ============================================================================
 
 test "live: Azure generateText" {
-    const api_key = getEnv("AZURE_API_KEY") orelse return;
-    const resource_name = getEnv("AZURE_RESOURCE_NAME") orelse return;
-    const deployment_name = getEnv("AZURE_DEPLOYMENT_NAME") orelse return;
+    const api_key = getEnv("AZURE_API_KEY") orelse return error.SkipZigTest;
+    const resource_name = getEnv("AZURE_RESOURCE_NAME") orelse return error.SkipZigTest;
+    const deployment_name = getEnv("AZURE_DEPLOYMENT_NAME") orelse return error.SkipZigTest;
     const allocator = testing.allocator;
 
     var http_client = provider_utils.createStdHttpClient(allocator);
@@ -207,9 +207,9 @@ test "live: Azure generateText" {
 
 test "live: Azure error diagnostic on invalid key" {
     const allocator = testing.allocator;
-    _ = getEnv("AZURE_API_KEY") orelse return;
-    const resource_name = getEnv("AZURE_RESOURCE_NAME") orelse return;
-    const deployment_name = getEnv("AZURE_DEPLOYMENT_NAME") orelse return;
+    _ = getEnv("AZURE_API_KEY") orelse return error.SkipZigTest;
+    const resource_name = getEnv("AZURE_RESOURCE_NAME") orelse return error.SkipZigTest;
+    const deployment_name = getEnv("AZURE_DEPLOYMENT_NAME") orelse return error.SkipZigTest;
 
     var http_client = provider_utils.createStdHttpClient(allocator);
     defer http_client.deinit();
@@ -238,9 +238,9 @@ test "live: Azure error diagnostic on invalid key" {
 }
 
 test "live: Azure streamText" {
-    const api_key = getEnv("AZURE_API_KEY") orelse return;
-    const resource_name = getEnv("AZURE_RESOURCE_NAME") orelse return;
-    const deployment_name = getEnv("AZURE_DEPLOYMENT_NAME") orelse return;
+    const api_key = getEnv("AZURE_API_KEY") orelse return error.SkipZigTest;
+    const resource_name = getEnv("AZURE_RESOURCE_NAME") orelse return error.SkipZigTest;
+    const deployment_name = getEnv("AZURE_DEPLOYMENT_NAME") orelse return error.SkipZigTest;
 
     const alloc = testing.allocator;
 
@@ -281,7 +281,7 @@ test "live: Azure streamText" {
 // ============================================================================
 
 test "live: Anthropic generateText" {
-    const api_key = getEnv("ANTHROPIC_API_KEY") orelse return;
+    const api_key = getEnv("ANTHROPIC_API_KEY") orelse return error.SkipZigTest;
     const allocator = testing.allocator;
 
     var http_client = provider_utils.createStdHttpClient(allocator);
@@ -309,7 +309,7 @@ test "live: Anthropic generateText" {
 
 test "live: Anthropic error diagnostic on invalid key" {
     const allocator = testing.allocator;
-    _ = getEnv("ANTHROPIC_API_KEY") orelse return;
+    _ = getEnv("ANTHROPIC_API_KEY") orelse return error.SkipZigTest;
 
     var http_client = provider_utils.createStdHttpClient(allocator);
     defer http_client.deinit();
@@ -337,7 +337,7 @@ test "live: Anthropic error diagnostic on invalid key" {
 }
 
 test "live: Anthropic streamText" {
-    const api_key = getEnv("ANTHROPIC_API_KEY") orelse return;
+    const api_key = getEnv("ANTHROPIC_API_KEY") orelse return error.SkipZigTest;
     const alloc = testing.allocator;
 
     var http_client = provider_utils.createStdHttpClient(alloc);
@@ -376,7 +376,7 @@ test "live: Anthropic streamText" {
 // ============================================================================
 
 test "live: Google generateText" {
-    const api_key = getEnv("GOOGLE_GENERATIVE_AI_API_KEY") orelse return;
+    const api_key = getEnv("GOOGLE_GENERATIVE_AI_API_KEY") orelse return error.SkipZigTest;
     const allocator = testing.allocator;
 
     var http_client = provider_utils.createStdHttpClient(allocator);
@@ -404,7 +404,7 @@ test "live: Google generateText" {
 
 test "live: Google error diagnostic on invalid key" {
     const allocator = testing.allocator;
-    _ = getEnv("GOOGLE_GENERATIVE_AI_API_KEY") orelse return;
+    _ = getEnv("GOOGLE_GENERATIVE_AI_API_KEY") orelse return error.SkipZigTest;
 
     var http_client = provider_utils.createStdHttpClient(allocator);
     defer http_client.deinit();
@@ -432,7 +432,7 @@ test "live: Google error diagnostic on invalid key" {
 }
 
 test "live: Google streamText" {
-    const api_key = getEnv("GOOGLE_GENERATIVE_AI_API_KEY") orelse return;
+    const api_key = getEnv("GOOGLE_GENERATIVE_AI_API_KEY") orelse return error.SkipZigTest;
     const alloc = testing.allocator;
 
     var http_client = provider_utils.createStdHttpClient(alloc);
@@ -471,7 +471,7 @@ test "live: Google streamText" {
 // ============================================================================
 
 test "live: xAI generateText" {
-    const api_key = getEnv("XAI_API_KEY") orelse return;
+    const api_key = getEnv("XAI_API_KEY") orelse return error.SkipZigTest;
     const allocator = testing.allocator;
 
     var http_client = provider_utils.createStdHttpClient(allocator);
@@ -499,7 +499,7 @@ test "live: xAI generateText" {
 
 test "live: xAI error diagnostic on invalid key" {
     const allocator = testing.allocator;
-    _ = getEnv("XAI_API_KEY") orelse return;
+    _ = getEnv("XAI_API_KEY") orelse return error.SkipZigTest;
 
     var http_client = provider_utils.createStdHttpClient(allocator);
     defer http_client.deinit();
@@ -528,7 +528,7 @@ test "live: xAI error diagnostic on invalid key" {
 }
 
 test "live: xAI streamText" {
-    const api_key = getEnv("XAI_API_KEY") orelse return;
+    const api_key = getEnv("XAI_API_KEY") orelse return error.SkipZigTest;
     const alloc = testing.allocator;
 
     var http_client = provider_utils.createStdHttpClient(alloc);


### PR DESCRIPTION
## Summary

- **Live tests**: Changed 15 `orelse return` → `orelse return error.SkipZigTest` so the Zig test runner reports "SKIP" instead of false "passed" when API keys are missing
- **Unit tests**: Removed 8 assertion-free tests (6 "deinit is safe" + 2 "inherits base_url") across togetherai, perplexity, huggingface, azure, deepinfra, and cerebras providers
- **Docs**: Updated test counts in README.md and CHANGELOG.md to reflect actual count (830+)

Fixes #101

## Test plan

- [x] `zig build test` — 831 tests pass (previously ~839, minus 8 removed)
- [ ] `zig build test-live` without keys — should show 15 skipped, 0 passed, 0 failed
- [ ] `./scripts/test-live.sh` with keys — live tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)