### PR TITLE
test: add live integration tests for tool calling

### DIFF
--- a/tests/integration/live_provider_test.zig
+++ b/tests/integration/live_provider_test.zig
@@ -7,6 +7,7 @@ const GenerateTextError = ai.generate_text.GenerateTextError;
 const StreamTextError = ai.generate_text.StreamTextError;
 const StreamPart = ai.StreamPart;
 const StreamCallbacks = ai.StreamCallbacks;
+const ToolDefinition = ai.generate_text.ToolDefinition;
 
 // Provider imports
 const openai = @import("openai");
@@ -560,4 +561,130 @@ test "live: xAI streamText" {
     try testing.expect(ctx.text_buf.items.len > 0);
     try testing.expect(ctx.error_count == 0);
     try testing.expect(stream_result.getText().len > 0);
+}
+
+// ============================================================================
+// Tool Calling (requires tools passthrough fix #103)
+// ============================================================================
+
+const weather_tool_schema =
+    \\{"type":"object","properties":{"location":{"type":"string","description":"City name"}},"required":["location"]}
+;
+
+fn parseWeatherSchema(allocator: std.mem.Allocator) !std.json.Parsed(std.json.Value) {
+    return std.json.parseFromSlice(std.json.Value, allocator, weather_tool_schema, .{});
+}
+
+test "live: OpenAI tool calling" {
+    const api_key = getEnv("OPENAI_API_KEY") orelse return error.SkipZigTest;
+    const allocator = testing.allocator;
+
+    var http_client = provider_utils.createStdHttpClient(allocator);
+    defer http_client.deinit();
+
+    var provider = openai.createOpenAIWithSettings(allocator, .{
+        .api_key = api_key,
+        .http_client = http_client.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.languageModel("gpt-4o-mini");
+    var lm = model.asLanguageModel();
+
+    var schema = try parseWeatherSchema(allocator);
+    defer schema.deinit();
+
+    const tools = [_]ToolDefinition{.{
+        .name = "get_weather",
+        .description = "Get the current weather for a location",
+        .parameters = schema.value,
+    }};
+
+    var result = try ai.generateText(allocator, .{
+        .model = &lm,
+        .prompt = "What's the weather in Paris?",
+        .tools = &tools,
+        .tool_choice = .required,
+    });
+    defer result.deinit(allocator);
+
+    try testing.expect(result.finish_reason == .tool_calls);
+    try testing.expect(result.tool_calls.len > 0);
+    try testing.expectEqualStrings("get_weather", result.tool_calls[0].tool_name);
+}
+
+test "live: Anthropic tool calling" {
+    const api_key = getEnv("ANTHROPIC_API_KEY") orelse return error.SkipZigTest;
+    const allocator = testing.allocator;
+
+    var http_client = provider_utils.createStdHttpClient(allocator);
+    defer http_client.deinit();
+
+    var provider = anthropic.createAnthropicWithSettings(allocator, .{
+        .api_key = api_key,
+        .http_client = http_client.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.languageModel("claude-sonnet-4-5-20250929");
+    var lm = model.asLanguageModel();
+
+    var schema = try parseWeatherSchema(allocator);
+    defer schema.deinit();
+
+    const tools = [_]ToolDefinition{.{
+        .name = "get_weather",
+        .description = "Get the current weather for a location",
+        .parameters = schema.value,
+    }};
+
+    var result = try ai.generateText(allocator, .{
+        .model = &lm,
+        .prompt = "What's the weather in Paris?",
+        .tools = &tools,
+        .tool_choice = .required,
+    });
+    defer result.deinit(allocator);
+
+    try testing.expect(result.finish_reason == .tool_calls);
+    try testing.expect(result.tool_calls.len > 0);
+    try testing.expectEqualStrings("get_weather", result.tool_calls[0].tool_name);
+}
+
+test "live: Google tool calling" {
+    const api_key = getEnv("GOOGLE_GENERATIVE_AI_API_KEY") orelse return error.SkipZigTest;
+    const allocator = testing.allocator;
+
+    var http_client = provider_utils.createStdHttpClient(allocator);
+    defer http_client.deinit();
+
+    var provider = google.createGoogleGenerativeAIWithSettings(allocator, .{
+        .api_key = api_key,
+        .http_client = http_client.asInterface(),
+    });
+    defer provider.deinit();
+
+    var model = provider.languageModel("gemini-2.0-flash");
+    var lm = model.asLanguageModel();
+
+    var schema = try parseWeatherSchema(allocator);
+    defer schema.deinit();
+
+    const tools = [_]ToolDefinition{.{
+        .name = "get_weather",
+        .description = "Get the current weather for a location",
+        .parameters = schema.value,
+    }};
+
+    var result = try ai.generateText(allocator, .{
+        .model = &lm,
+        .prompt = "What's the weather in Paris?",
+        .tools = &tools,
+        .tool_choice = .required,
+    });
+    defer result.deinit(allocator);
+
+    try testing.expect(result.finish_reason == .tool_calls);
+    try testing.expect(result.tool_calls.len > 0);
+    try testing.expectEqualStrings("get_weather", result.tool_calls[0].tool_name);
 }


### PR DESCRIPTION
## Summary

- Adds 3 live integration tests for tool calling: OpenAI (gpt-4o-mini), Anthropic (claude-sonnet-4-5-20250929), Google (gemini-2.0-flash)
- Each test defines a `get_weather` tool with JSON schema, calls `generateText` with `tool_choice = .required`
- Verifies `finish_reason == .tool_calls`, `tool_calls.len > 0`, and tool name matches

## Test plan

- [x] `zig build test` — all unit tests pass, new tests compile
- [ ] `./scripts/test-live.sh` — tests pass with API keys, skip without

Fixes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)