### PR TITLE
Fix live test compilation errors

### DIFF
--- a/packages/google-vertex/src/google-vertex-embedding-model.zig
+++ b/packages/google-vertex/src/google-vertex-embedding-model.zig
@@ -174,8 +174,7 @@ pub const GoogleVertexEmbeddingModel = struct {
         };
 
         // Serialize request body
-        var body_buffer = std.ArrayList(u8).empty;
-        std.json.stringify(.{ .object = body }, .{}, body_buffer.writer(request_allocator)) catch |err| {
+        const body_bytes = std.json.Stringify.valueAlloc(request_allocator, std.json.Value{ .object = body }, .{}) catch |err| {
             callback(callback_context, .{ .failure = err });
             return;
         };
@@ -212,7 +211,7 @@ pub const GoogleVertexEmbeddingModel = struct {
                 .method = .POST,
                 .url = url,
                 .headers = header_list.items,
-                .body = body_buffer.items,
+                .body = body_bytes,
             },
             request_allocator,
             struct {

--- a/packages/google-vertex/src/google-vertex-image-model.zig
+++ b/packages/google-vertex/src/google-vertex-image-model.zig
@@ -347,8 +347,7 @@ pub const GoogleVertexImageModel = struct {
         };
 
         // Serialize request body
-        var body_buffer = std.ArrayList(u8).empty;
-        std.json.stringify(.{ .object = body }, .{}, body_buffer.writer(request_allocator)) catch |err| {
+        const body_bytes = std.json.Stringify.valueAlloc(request_allocator, std.json.Value{ .object = body }, .{}) catch |err| {
             callback(callback_context, .{ .failure = err });
             return;
         };
@@ -385,7 +384,7 @@ pub const GoogleVertexImageModel = struct {
                 .method = .POST,
                 .url = url,
                 .headers = header_list.items,
-                .body = body_buffer.items,
+                .body = body_bytes,
             },
             request_allocator,
             struct {

--- a/packages/google/src/google-generative-ai-image-model.zig
+++ b/packages/google/src/google-generative-ai-image-model.zig
@@ -184,8 +184,7 @@ pub const GoogleGenerativeAIImageModel = struct {
         };
 
         // Serialize request body
-        var body_buffer = std.ArrayList(u8).empty;
-        std.json.stringify(.{ .object = body }, .{}, body_buffer.writer(request_allocator)) catch |err| {
+        const body_bytes = std.json.Stringify.valueAlloc(request_allocator, std.json.Value{ .object = body }, .{}) catch |err| {
             callback(callback_context, .{ .failure = err });
             return;
         };
@@ -222,7 +221,7 @@ pub const GoogleGenerativeAIImageModel = struct {
                 .method = .POST,
                 .url = url,
                 .headers = header_list.items,
-                .body = body_buffer.items,
+                .body = body_bytes,
             },
             request_allocator,
             struct {

--- a/tests/integration/live_provider_test.zig
+++ b/tests/integration/live_provider_test.zig
@@ -960,7 +960,7 @@ test "live: OpenAI embed" {
     var model = provider.embeddingModel("text-embedding-3-small");
     var em = model.asEmbeddingModel();
 
-    var result = ai.embed(allocator, .{
+    const result = ai.embed(allocator, .{
         .model = &em,
         .value = "Hello world",
     }) catch |err| {
@@ -990,7 +990,7 @@ test "live: OpenAI embedMany" {
     var em = model.asEmbeddingModel();
 
     const inputs = [_][]const u8{ "Hello", "World", "Test" };
-    var result = ai.embedMany(allocator, .{
+    const result = ai.embedMany(allocator, .{
         .model = &em,
         .values = &inputs,
     }) catch |err| {
@@ -1024,7 +1024,7 @@ test "live: Google embed" {
     var model = provider.embeddingModel("text-embedding-004");
     var em = model.asEmbeddingModel();
 
-    var result = ai.embed(allocator, .{
+    const result = ai.embed(allocator, .{
         .model = &em,
         .value = "Hello world",
     }) catch |err| {
@@ -1053,7 +1053,7 @@ test "live: Google embedMany" {
     var em = model.asEmbeddingModel();
 
     const inputs = [_][]const u8{ "Hello", "World", "Test" };
-    var result = ai.embedMany(allocator, .{
+    const result = ai.embedMany(allocator, .{
         .model = &em,
         .values = &inputs,
     }) catch |err| {


### PR DESCRIPTION
## Summary

- Fix 4x `var` → `const` for unmutated embed/embedMany results in live tests
- Replace `try body.put(...)` with `catch` pattern in google embedding model (void-returning function)
- Replace `std.json.stringify` with `std.json.Stringify.valueAlloc` across 4 google/vertex model files (Zig 0.15 API change)
- Fix incorrect struct initialization for `ArrayList([]const f32).append` in google embedding model

Fixes #113

## Test plan

- [x] `zig build test` — 42/42 tests pass (no regressions)
- [x] `zig build test-live` — compiles successfully (tests skip without API keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)