### PR TITLE
Update docs for live test coverage additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2026-02-16
+
+### Added
+
+- **Live integration tests for tool calling**: OpenAI, Anthropic, Google (#106)
+- **Live integration tests for `generateObject`**: OpenAI, Anthropic, Google (#108)
+- **Live integration tests for `streamObject`**: OpenAI, Google (#110)
+- **Live integration tests for `embed` / `embedMany`**: OpenAI, Google (#112)
+
+### Fixed
+
+- **Tool calling**: Pass `tools` and `tool_choice` through to provider `call_options` (#104)
+- **Live test compilation**: `var`→`const` for unmutated results, `try` in void-returning function, `std.json.stringify`→`Stringify.valueAlloc` (Zig 0.15 API), incorrect embed list append (#114)
+
+### Changed
+
+- 810+ unit tests, 27 live integration tests across all packages
+
 ## [0.2.1] - 2026-02-15
 
 ### Fixed
@@ -25,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- 830+ unit tests passing across all packages (#84-#98)
+- 810+ unit tests passing across all packages (#84-#98)
 
 ## [0.2.0] - 2026-02-14
 
@@ -59,7 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Consolidated to 14 working provider packages: OpenAI, Anthropic, Google, Google Vertex, Azure, xAI, Perplexity, Together AI, Fireworks, Cerebras, DeepInfra, HuggingFace, OpenAI Compatible, and provider-utils
 - Updated documentation: README, CLAUDE.md, `.env.example` (#80)
-- 830+ unit tests passing across all packages
+- 810+ unit tests passing across all packages
 
 ## [0.1.0] - 2024-12-19
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to the Zig AI SDK!
 
 ## Development Setup
 
-1. **Install Zig**: Ensure you have Zig 0.13.0 or later installed
+1. **Install Zig**: Ensure you have Zig 0.15.0 or later installed
    ```bash
    # Check your Zig version
    zig version
@@ -12,8 +12,8 @@ Thank you for your interest in contributing to the Zig AI SDK!
 
 2. **Clone the repository**:
    ```bash
-   git clone https://github.com/your-org/zig-ai-sdk.git
-   cd zig-ai-sdk
+   git clone https://github.com/evmts/ai-zig.git
+   cd ai-zig
    ```
 
 3. **Build the project**:
@@ -42,7 +42,7 @@ Thank you for your interest in contributing to the Zig AI SDK!
 2. Create the provider file following this pattern:
    ```zig
    const std = @import("std");
-   const provider_v3 = @import("../../provider/src/provider/v3/index.zig");
+   const provider = @import("provider");
 
    pub const MyProviderSettings = struct {
        base_url: ?[]const u8 = null,
@@ -91,15 +91,7 @@ Thank you for your interest in contributing to the Zig AI SDK!
    }
    ```
 
-4. Add the provider to `build.zig`:
-   ```zig
-   const my_provider_mod = b.addModule("my-provider", .{
-       .root_source_file = b.path("packages/my-provider/src/index.zig"),
-       .target = target,
-       .optimize = optimize,
-   });
-   my_provider_mod.addImport("provider", provider_mod);
-   ```
+4. Add the provider to `build.zig` — add an entry to the `test_configs` array and create a module with appropriate imports. See existing providers in `build.zig` for the current pattern.
 
 5. Add tests in the provider file and integration tests
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ ai-zig/
 
 ## Testing
 
-The SDK includes comprehensive unit tests (830+ passing, including ~33 compilation-verification tests via `refAllDecls`):
+The SDK includes comprehensive tests (810+ unit tests plus 27 live integration tests across 5 providers):
 
 ```bash
 zig build test
@@ -287,20 +287,18 @@ try std.testing.expectEqualStrings("POST", req.method.toString());
 - `generateText` / `streamText` - text generation and streaming
 - `generateObject` / `streamObject` - structured JSON output with schema validation
 - Tool execution with agentic loop (multi-step)
+- `embed` / `embedMany` - text embedding generation (OpenAI, Google)
 - 5 providers tested: OpenAI, Anthropic, Google, Azure, xAI
 
 ### Working (unit tests only)
-- `embed` / `embedMany` - text embedding generation
 - Middleware chain (rate limiting)
 - `RetryPolicy`, `RequestContext`
 - `generateImage`, `generateSpeech`, `transcribe` - API surface exists, no provider implementations yet
 
 ### Known Issues
-- **Live test coverage**: Live integration tests only cover basic `generateText`/`streamText` and error diagnostics; tool calling, `generateObject`, `streamObject`, and embeddings are not yet tested against real APIs
 - **`ignore_unknown_fields`**: Response structs cover common fields but not every API response field; `ignore_unknown_fields = true` is used for forward compatibility
 
 ### Planned
-- Live integration tests for tool calling, structured output, and embeddings
 - Re-enable removed providers (Mistral, Groq, DeepSeek, Cohere, Bedrock, etc.)
 - Image generation providers (Fal, FLUX, DALL-E)
 - Speech/audio providers (ElevenLabs, Deepgram, etc.)


### PR DESCRIPTION
## Summary

- Update test counts: "830+" → "810+ unit tests plus 27 live integration tests"
- Move `embed`/`embedMany` from "unit tests only" to "live-tested" in README roadmap
- Remove completed items from Known Issues and Planned sections
- Add CHANGELOG `[0.2.2]` section for PRs #104-#114
- Fix CONTRIBUTING.md: Zig version (0.13 → 0.15), repo URL, import path, build.zig example

Fixes #115

## Test plan

- [x] Doc-only changes, `zig build test` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)