### PR TITLE
Add image understanding tests and fix multimodal content

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,3 +181,17 @@ The `@alignCast` is safe when:
 2. The vtable and impl are always paired correctly (same instance)
 
 All vtable implementations in this codebase follow this pattern, ensuring alignment is preserved through the type-erasure round-trip.
+
+## JSON Parsing and Serialization Conventions
+
+### Response Parsing (`ignore_unknown_fields`)
+
+Provider response structs should capture **all known fields** from the API. When adding or modifying response parsing:
+
+1. **During development**: Set `ignore_unknown_fields = false` (strict mode) and run live tests. If parsing fails, identify the unknown field(s) from the API response and add them to the response struct.
+2. **Once all fields are captured**: Set `ignore_unknown_fields = true` for production resilience. This ensures apps built on this library won't break when a provider adds new response fields.
+3. **If a user reports a missing field**: Repeat the process — temporarily set to `false`, identify the new field, add it, then set back to `true`.
+
+### Request Serialization (`emit_null_optional_fields`)
+
+Set `emit_null_optional_fields = false` when serializing API requests. Some providers (e.g., OpenAI's gpt-image-1) reject parameters that are valid for other models in the same family (e.g., `"style"` is valid for dall-e-3 but rejected by gpt-image-1). Omitting null optional fields avoids sending parameters the user hasn't explicitly set, preventing these cross-model compatibility errors.

--- a/packages/openai/src/image/openai-image-api.zig
+++ b/packages/openai/src/image/openai-image-api.zig
@@ -16,9 +16,16 @@ pub const OpenAIImageResponse = struct {
         revised_prompt: ?[]const u8 = null,
     };
 
+    pub const TokensDetails = struct {
+        image_tokens: ?u64 = null,
+        text_tokens: ?u64 = null,
+    };
+
     pub const Usage = struct {
         input_tokens: ?u64 = null,
+        input_tokens_details: ?TokensDetails = null,
         output_tokens: ?u64 = null,
+        output_tokens_details: ?TokensDetails = null,
         total_tokens: ?u64 = null,
     };
 };

--- a/packages/openai/src/image/openai-image-model.zig
+++ b/packages/openai/src/image/openai-image-model.zig
@@ -177,7 +177,7 @@ pub const OpenAIImageModel = struct {
         }
         const response_body = http_response.body;
 
-        // Parse response (ignore unknown fields for forward compatibility)
+        // Parse response (ignore unknown fields for forward compatibility with API changes)
         const parsed = std.json.parseFromSlice(api.OpenAIImageResponse, request_allocator, response_body, .{ .ignore_unknown_fields = true }) catch {
             return error.InvalidResponse;
         };
@@ -275,6 +275,8 @@ pub const GenerateResult = im.ImageModelV3.GenerateResult;
 
 /// Serialize request to JSON
 fn serializeRequest(allocator: std.mem.Allocator, request: api.OpenAIImageGenerationRequest) ![]const u8 {
+    // Must omit null fields: gpt-image-1 rejects unknown parameters like "style"
+    // that are valid for dall-e-3 but not for this model.
     return std.json.Stringify.valueAlloc(allocator, request, .{ .emit_null_optional_fields = false });
 }
 


### PR DESCRIPTION
## Summary
- Implement `.parts` content conversion in generate-text, stream-text, and stream-object so multimodal messages (text + images) actually reach providers (was empty no-op)
- Fix OpenAI image generation: `ignore_unknown_fields` for JSON forward compat, `emit_null_optional_fields = false` for proper serialization, memory leak fixes (model_id dupe, warnings allocation)
- Fix OpenAI data URI construction for vision — base64 images now get proper `data:<mime>;base64,<data>` format
- Fix intermediate base64 slice memory leak in `generateImage`
- Add 4 new live integration tests: OpenAI + Google image generation and image understanding (vision)

## Test plan
- [x] `zig build test` — all unit tests pass (1139+)
- [x] `./scripts/test-live.sh` — all 4 image tests pass (22 total pass, 9 pre-existing failures unchanged)
- [x] OpenAI gpt-image-1 generates image successfully
- [x] Google gemini-3-pro-image-preview generates image successfully
- [x] OpenAI gpt-4o-mini correctly describes generated image via vision
- [x] Google gemini-2.0-flash correctly describes generated image via vision

Fixes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)