### PR TITLE
Fix 9 failing live integration tests (memory leaks + missing status check)

### DIFF
--- a/packages/ai/src/generate-object/stream-object.zig
+++ b/packages/ai/src/generate-object/stream-object.zig
@@ -403,7 +403,7 @@ pub fn streamObject(
     // completes all callbacks synchronously before returning.
     var bridge = BridgeCtx{ .res = result, .cbs = options.callbacks, .schema = options.schema.json_schema };
     const bridge_ptr: *anyopaque = @ptrCast(&bridge);
-    options.model.doStream(call_options, allocator, .{
+    options.model.doStream(call_options, arena_allocator, .{
         .on_part = BridgeCtx.onPart,
         .on_error = BridgeCtx.onError,
         .on_complete = BridgeCtx.onComplete,

--- a/packages/anthropic/src/anthropic-messages-language-model.zig
+++ b/packages/anthropic/src/anthropic-messages-language-model.zig
@@ -603,7 +603,7 @@ const StreamState = struct {
                             .input = std.ArrayList(u8).empty,
                         });
                         self.callbacks.on_part(self.callbacks.ctx, .{
-                            .text_start = .{ .id = try std.fmt.allocPrint(self.result_allocator, "{d}", .{index}) },
+                            .text_start = .{ .id = try std.fmt.allocPrint(self.stream_allocator, "{d}", .{index}) },
                         });
                     },
                     .thinking => {
@@ -612,7 +612,7 @@ const StreamState = struct {
                             .input = std.ArrayList(u8).empty,
                         });
                         self.callbacks.on_part(self.callbacks.ctx, .{
-                            .reasoning_start = .{ .id = try std.fmt.allocPrint(self.result_allocator, "{d}", .{index}) },
+                            .reasoning_start = .{ .id = try std.fmt.allocPrint(self.stream_allocator, "{d}", .{index}) },
                         });
                     },
                     .tool_use => |tu| {
@@ -640,7 +640,7 @@ const StreamState = struct {
                     .text_delta => |td| {
                         self.callbacks.on_part(self.callbacks.ctx, .{
                             .text_delta = .{
-                                .id = try std.fmt.allocPrint(self.result_allocator, "{d}", .{index}),
+                                .id = try std.fmt.allocPrint(self.stream_allocator, "{d}", .{index}),
                                 .delta = td.text,
                             },
                         });
@@ -648,7 +648,7 @@ const StreamState = struct {
                     .thinking_delta => |td| {
                         self.callbacks.on_part(self.callbacks.ctx, .{
                             .reasoning_delta = .{
-                                .id = try std.fmt.allocPrint(self.result_allocator, "{d}", .{index}),
+                                .id = try std.fmt.allocPrint(self.stream_allocator, "{d}", .{index}),
                                 .delta = td.thinking,
                             },
                         });
@@ -672,7 +672,7 @@ const StreamState = struct {
             const index = chunk.index orelse return;
 
             if (self.content_blocks.get(index)) |block| {
-                const id = try std.fmt.allocPrint(self.result_allocator, "{d}", .{index});
+                const id = try std.fmt.allocPrint(self.stream_allocator, "{d}", .{index});
 
                 switch (block.block_type) {
                     .text => {

--- a/packages/google/src/google-generative-ai-language-model.zig
+++ b/packages/google/src/google-generative-ai-language-model.zig
@@ -365,7 +365,7 @@ pub const GoogleGenerativeAILanguageModel = struct {
                                             self.is_text_active = true;
                                         }
                                         // Emit text delta
-                                        const text_copy = self.result_allocator.dupe(u8, text) catch continue;
+                                        const text_copy = self.request_allocator.dupe(u8, text) catch continue;
                                         self.callbacks.on_part(self.callbacks.ctx, .{
                                             .text_delta = .{ .id = "text", .delta = text_copy },
                                         });
@@ -378,12 +378,12 @@ pub const GoogleGenerativeAILanguageModel = struct {
                                                 self.callbacks.on_error(self.callbacks.ctx, err);
                                                 return;
                                             };
-                                            args_str = self.result_allocator.dupe(u8, serialized) catch "{}";
+                                            args_str = self.request_allocator.dupe(u8, serialized) catch "{}";
                                         }
                                         self.callbacks.on_part(self.callbacks.ctx, .{
                                             .tool_call = .{
-                                                .tool_call_id = self.result_allocator.dupe(u8, fc.name) catch "",
-                                                .tool_name = self.result_allocator.dupe(u8, fc.name) catch "",
+                                                .tool_call_id = self.request_allocator.dupe(u8, fc.name) catch "",
+                                                .tool_name = self.request_allocator.dupe(u8, fc.name) catch "",
                                                 .input = args_str,
                                             },
                                         });

--- a/tests/integration/live_provider_test.zig
+++ b/tests/integration/live_provider_test.zig
@@ -142,10 +142,12 @@ test "live: OpenAI streamText" {
     const alloc = testing.allocator;
 
     var http_client = provider_utils.createStdHttpClient(alloc);
+    defer http_client.deinit();
     var provider = openai.createOpenAIWithSettings(alloc, .{
         .api_key = api_key,
         .http_client = http_client.asInterface(),
     });
+    defer provider.deinit();
 
     var model = provider.languageModel("gpt-4o-mini");
     var lm = model.asLanguageModel();
@@ -246,11 +248,13 @@ test "live: Azure streamText" {
     const alloc = testing.allocator;
 
     var http_client = provider_utils.createStdHttpClient(alloc);
+    defer http_client.deinit();
     var provider = azure.createAzureWithSettings(alloc, .{
         .api_key = api_key,
         .resource_name = resource_name,
         .http_client = http_client.asInterface(),
     });
+    defer provider.deinit();
 
     var model = provider.chat(deployment_name);
     var lm = model.asLanguageModel();
@@ -342,10 +346,12 @@ test "live: Anthropic streamText" {
     const alloc = testing.allocator;
 
     var http_client = provider_utils.createStdHttpClient(alloc);
+    defer http_client.deinit();
     var provider = anthropic.createAnthropicWithSettings(alloc, .{
         .api_key = api_key,
         .http_client = http_client.asInterface(),
     });
+    defer provider.deinit();
 
     var model = provider.languageModel("claude-sonnet-4-5-20250929");
     var lm = model.asLanguageModel();
@@ -437,10 +443,12 @@ test "live: Google streamText" {
     const alloc = testing.allocator;
 
     var http_client = provider_utils.createStdHttpClient(alloc);
+    defer http_client.deinit();
     var provider = google.createGoogleGenerativeAIWithSettings(alloc, .{
         .api_key = api_key,
         .http_client = http_client.asInterface(),
     });
+    defer provider.deinit();
 
     var model = provider.languageModel("gemini-2.0-flash");
     var lm = model.asLanguageModel();
@@ -533,10 +541,12 @@ test "live: xAI streamText" {
     const alloc = testing.allocator;
 
     var http_client = provider_utils.createStdHttpClient(alloc);
+    defer http_client.deinit();
     var provider = xai.createXaiWithSettings(alloc, .{
         .api_key = api_key,
         .http_client = http_client.asInterface(),
     });
+    defer provider.deinit();
 
     var model = provider.languageModel("grok-3-mini-fast");
     var lm = model.asLanguageModel();


### PR DESCRIPTION
## Summary

- Add missing `defer http_client.deinit()` and `defer provider.deinit()` to all 5 streamText live tests (OpenAI, Azure, Anthropic, Google, xAI)
- Switch Anthropic streaming from `result_allocator` to `stream_allocator` for ephemeral text/reasoning block IDs (5 `allocPrint` calls)
- Switch Google streaming from `result_allocator` to `request_allocator` for text copies and function call args/names (5 allocations)
- Pass `arena_allocator` instead of base `allocator` to `doGenerate` in `generateObject`, dupe `raw_text`/`id`/`model_id` to base allocator with proper cleanup in `deinit`
- Pass `arena_allocator` instead of base `allocator` to `doStream` in `streamObject`
- Add HTTP status code capture and validation in Google embedding model before parsing response body

## Test plan

- [x] `zig build test` — all 124 unit test groups pass
- [ ] `./scripts/test-live.sh` — verify 9 previously-failing tests now pass

Fixes #121